### PR TITLE
TV: QWERTY keyboard, All-sources search, History continue, sniff flag + lists data layer

### DIFF
--- a/app/src/main/java/com/saikou/sozo_tv/data/extensions/ExtModels.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/extensions/ExtModels.kt
@@ -112,6 +112,15 @@ data class ExtVideoSource(
     val useLocalProxy: Boolean = false,
     val localProxy: String? = null,        // raw JSON
     val requestTransform: String? = null,  // raw JSON
+    /**
+     * Server-set capability flag: this source's real manifest only exists after
+     * the page's own JS runs, so play it by sniffing a headless WebView rather
+     * than handing the url to ExoPlayer. Never branch on the provider id — any
+     * source carrying this flag takes the same path, so a new site like it is a
+     * backend-only change.
+     */
+    val useWebViewSniff: Boolean = false,
+    val sniff: String? = null,             // raw JSON: patterns/timeoutMs/headers/blockHosts
 )
 
 data class ExtSubtitle(val label: String, val file: String, val default: Boolean)
@@ -279,6 +288,10 @@ internal object ExtParser {
                 isDefault = s.optBoolean("isDefault", i == 0),
                 headers = s.headersMap("headers"),
                 useLocalProxy = s.optBoolean("useLocalProxy", false),
+                // Fall back to the media-level flag: a provider may declare the
+                // capability once for the whole payload rather than per source.
+                useWebViewSniff = s.optBoolean("useWebViewSniff", o.optBoolean("useWebViewSniff", false)),
+                sniff = (s.optJSONObject("sniff") ?: o.optJSONObject("sniff"))?.toString(),
                 localProxy = s.optJSONObject("localProxy")?.toString(),
                 requestTransform = s.optJSONObject("requestTransform")?.toString(),
             )

--- a/app/src/main/java/com/saikou/sozo_tv/data/extensions/ExtensionEngine.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/extensions/ExtensionEngine.kt
@@ -213,6 +213,50 @@ class ExtensionEngine(private val appContext: Context = MyApp.context) {
         ExtParser.page(b.searchJson(p, query))
     }
 
+    /**
+     * "All sources": search every installed provider across all three groups
+     * instead of only the active one.
+     *
+     * Three bounds, all load-bearing — a CloudStream repo alone can install
+     * dozens of providers, and a naive fan-out would hang the screen on the
+     * slowest dead mirror:
+     *   - [maxProviders] caps how many are queried at all,
+     *   - [perProviderTimeoutMs] caps each one INDEPENDENTLY, so one stalled
+     *     source costs its own slot and nothing else,
+     *   - a throwing/empty source is dropped rather than failing the search.
+     *
+     * The active provider is queried FIRST so its hits lead the merged list —
+     * that is the source the user already chose. Results are deduped on
+     * (provider, contentUrl): the same title legitimately appears on several
+     * sources and each is separately playable, so only exact repeats collapse.
+     */
+    suspend fun searchAll(
+        query: String,
+        maxProviders: Int = MAX_GLOBAL_PROVIDERS,
+        perProviderTimeoutMs: Long = GLOBAL_SEARCH_TIMEOUT_MS,
+    ): List<ExtCard> = withContext(Dispatchers.IO) {
+        val q = query.trim()
+        if (q.isEmpty()) return@withContext emptyList()
+
+        val active = getActiveProvider()
+        val candidates = listOf(ExtGroup.SERVER, ExtGroup.ANIYOMI, ExtGroup.CLOUDSTREAM)
+            .flatMap { g -> runCatching { providers(g) }.getOrDefault(emptyList()) }
+            .distinctBy { it.id }
+            .sortedByDescending { it.id == active }
+            .take(maxProviders)
+
+        val pages = candidates.map { p ->
+            async {
+                withTimeoutOrNull(perProviderTimeoutMs) {
+                    runCatching { search(p.id, q)?.items }.getOrNull().orEmpty()
+                }.orEmpty()
+            }
+        }.map { it.await() }
+
+        val seen = HashSet<String>()
+        pages.flatten().filter { seen.add("${it.provider}|${it.contentUrl}") }
+    }
+
     suspend fun load(provider: String, url: String): ExtDetail? = withContext(Dispatchers.IO) {
         val b = backendForProvider(provider) ?: return@withContext null
         b.ensureLoaded()
@@ -237,6 +281,10 @@ class ExtensionEngine(private val appContext: Context = MyApp.context) {
         private const val KEY_PROVIDER = "active_provider"
         private const val KEY_PROVIDER_NAME = "active_provider_name"
         private const val HOME_TIMEOUT_MS = 25_000L
+
+        /** Global-search bounds — see [searchAll]. */
+        private const val MAX_GLOBAL_PROVIDERS = 12
+        private const val GLOBAL_SEARCH_TIMEOUT_MS = 12_000L
 
         val shared: ExtensionEngine by lazy { ExtensionEngine() }
     }

--- a/app/src/main/java/com/saikou/sozo_tv/data/remote/lists/UserListKind.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/remote/lists/UserListKind.kt
@@ -1,0 +1,12 @@
+package com.saikou.sozo_tv.data.remote.lists
+
+/**
+ * The user-curated lists the backend exposes at `/auth/lists/<slug>`.
+ *
+ * [slug] MUST match the server's registry (`authService.USER_LISTS`) and the
+ * Flutter enum of the same name — one list, three places, one spelling.
+ */
+enum class UserListKind(val slug: String, val label: String) {
+    WATCH_LATER("watch-later", "Watch Later"),
+    WATCHED("watched", "Watched"),
+}

--- a/app/src/main/java/com/saikou/sozo_tv/data/remote/lists/UserListsClient.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/remote/lists/UserListsClient.kt
@@ -1,0 +1,129 @@
+package com.saikou.sozo_tv.data.remote.lists
+
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import com.saikou.sozo_tv.data.remote.device.ApiResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+/** One entry in a curated list. Mirrors the server's list item shape. */
+data class UserListItem(
+    val provider: String? = null,
+    val contentUrl: String? = null,
+    val title: String? = null,
+    val thumbnail: String? = null,
+)
+
+private data class UserListResponse(
+    val kind: String? = null,
+    val items: List<UserListItem>? = null,
+)
+
+private data class AddRequest(
+    val provider: String,
+    val contentUrl: String,
+    val title: String?,
+    val thumbnail: String?,
+)
+
+private data class RemoveRequest(val contentUrl: String)
+
+private data class ApiMessage(@SerializedName("message") val message: String?)
+
+/**
+ * Transport for `/auth/lists/<kind>` — the TV's FIRST authenticated API surface.
+ *
+ * Until now the device session minted and rotated an access token that nothing
+ * ever spent (see DeviceAuthRepository). These lists live on the account, so
+ * every call here carries `Authorization: Bearer <access>`, supplied per-request
+ * by [tokenProvider] rather than captured once: the token is 15-minute lived and
+ * the repository refreshes it transparently, so a cached copy would go stale
+ * mid-session.
+ *
+ * Uses the same `authOkHttp` client as device sign-in — platform TLS, no
+ * body logging. The content client trusts any certificate, which must never
+ * carry a bearer token.
+ */
+class UserListsClient(
+    private val okHttpClient: OkHttpClient,
+    private val gson: Gson,
+    private val baseUrl: String,
+    private val tokenProvider: suspend () -> String?,
+) {
+
+    suspend fun get(kind: UserListKind): ApiResult<List<UserListItem>> =
+        request(kind, "GET", null, UserListResponse::class.java)
+            .map { it.items.orEmpty().filter { i -> !i.contentUrl.isNullOrBlank() } }
+
+    suspend fun add(kind: UserListKind, item: UserListItem): ApiResult<Unit> {
+        val provider = item.provider ?: return ApiResult.Http(400, "provider required", null)
+        val contentUrl = item.contentUrl ?: return ApiResult.Http(400, "contentUrl required", null)
+        return request(
+            kind, "POST",
+            AddRequest(provider, contentUrl, item.title, item.thumbnail),
+            ApiMessage::class.java,
+        ).map { }
+    }
+
+    suspend fun remove(kind: UserListKind, contentUrl: String): ApiResult<Unit> =
+        request(kind, "DELETE", RemoveRequest(contentUrl), ApiMessage::class.java).map { }
+
+    private inline fun <T, R> ApiResult<T>.map(transform: (T) -> R): ApiResult<R> = when (this) {
+        is ApiResult.Ok -> ApiResult.Ok(transform(body))
+        is ApiResult.Http -> this
+        is ApiResult.Network -> this
+    }
+
+    private suspend fun <T> request(
+        kind: UserListKind,
+        method: String,
+        body: Any?,
+        type: Class<T>,
+    ): ApiResult<T> = withContext(Dispatchers.IO) {
+        // No token => not signed in. Reported as 401 so callers branch on the
+        // code, never on message text (the server's errors are bare strings).
+        val token = runCatching { tokenProvider() }.getOrNull()
+            ?: return@withContext ApiResult.Http(401, "Not signed in", null)
+
+        try {
+            val payload = body?.let { gson.toJson(it).toRequestBody(JSON) }
+            val builder = Request.Builder()
+                .url("${baseUrl.trimEnd('/')}$PATH/${kind.slug}")
+                .addHeader("Authorization", "Bearer $token")
+                .addHeader("Accept", "application/json")
+            when (method) {
+                "GET" -> builder.get()
+                // DELETE carries a body here, which OkHttp allows and the
+                // server's express.json() parses.
+                else -> {
+                    builder.addHeader("Content-Type", "application/json")
+                    builder.method(method, payload ?: "".toRequestBody(JSON))
+                }
+            }
+
+            okHttpClient.newCall(builder.build()).execute().use { resp ->
+                val raw = resp.body.string()
+                if (!resp.isSuccessful) {
+                    val msg = runCatching { gson.fromJson(raw, ApiMessage::class.java)?.message }.getOrNull()
+                    return@use ApiResult.Http(
+                        resp.code, msg, resp.header("Retry-After")?.trim()?.toIntOrNull(),
+                    )
+                }
+                val parsed = runCatching { gson.fromJson(raw, type) }.getOrNull()
+                    ?: return@use ApiResult.Http(resp.code, "Empty response", null)
+                ApiResult.Ok(parsed)
+            }
+        } catch (t: Throwable) {
+            ApiResult.Network(t)
+        }
+    }
+
+    private companion object {
+        val JSON = "application/json; charset=utf-8".toMediaType()
+        const val PATH = "/auth/lists"
+    }
+}

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/SearchRepositoryImpl.kt
@@ -22,4 +22,13 @@ class SearchRepositoryImpl(
 
     override suspend fun searchAnime(query: String): Result<List<SearchModel>> = run(query)
     override suspend fun searchMovie(query: String): Result<List<SearchModel>> = run(query)
+
+    // No "no source selected" failure here on purpose: a global search does not
+    // depend on one being active, and an empty corpus is an empty RESULT, not an
+    // error the UI should render as a crash banner.
+    override suspend fun searchAllSources(query: String): Result<List<SearchModel>> = try {
+        Result.success(engine.searchAll(query).map { it.toSearchModel() })
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
 }

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/UserListsRepository.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/UserListsRepository.kt
@@ -1,0 +1,88 @@
+package com.saikou.sozo_tv.data.repository
+
+import android.content.Context
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.saikou.sozo_tv.data.remote.device.ApiResult
+import com.saikou.sozo_tv.data.remote.lists.UserListItem
+import com.saikou.sozo_tv.data.remote.lists.UserListKind
+import com.saikou.sozo_tv.data.remote.lists.UserListsClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Cache-first, server-authoritative — the same contract the Flutter client uses,
+ * so the two apps agree about what the user sees offline.
+ *
+ * The cache is a JSON blob in SharedPreferences rather than a Room table on
+ * purpose: adding entities to `AppDatabase` means a schema version bump, and a
+ * missing migration is a crash-on-launch for every existing install. These lists
+ * are small, bounded server-side at 500, and only ever read whole.
+ */
+class UserListsRepository(
+    context: Context,
+    private val client: UserListsClient,
+    private val gson: Gson = Gson(),
+) {
+
+    private val prefs = context.getSharedPreferences(FILE, Context.MODE_PRIVATE)
+    private val itemsType = object : TypeToken<List<UserListItem>>() {}.type
+
+    fun cached(kind: UserListKind): List<UserListItem> {
+        val raw = prefs.getString(kind.slug, null) ?: return emptyList()
+        return runCatching { gson.fromJson<List<UserListItem>>(raw, itemsType) }
+            .getOrNull()
+            ?.filter { !it.contentUrl.isNullOrBlank() }
+            ?: emptyList()
+    }
+
+    private fun store(kind: UserListKind, items: List<UserListItem>) {
+        prefs.edit().putString(kind.slug, gson.toJson(items)).apply()
+    }
+
+    fun contains(kind: UserListKind, contentUrl: String): Boolean =
+        cached(kind).any { it.contentUrl == contentUrl }
+
+    /**
+     * Fetch and replace the cache. A failed fetch keeps the last good copy —
+     * a curated list going blank because the network blinked is worse than a
+     * slightly stale one.
+     */
+    suspend fun refresh(kind: UserListKind): List<UserListItem> = withContext(Dispatchers.IO) {
+        when (val r = client.get(kind)) {
+            is ApiResult.Ok -> r.body.also { store(kind, it) }
+            else -> cached(kind)
+        }
+    }
+
+    /** Optimistic: the cache (and therefore the button) updates before the call. */
+    suspend fun add(kind: UserListKind, item: UserListItem) = withContext(Dispatchers.IO) {
+        val url = item.contentUrl ?: return@withContext
+        store(kind, listOf(item) + cached(kind).filterNot { it.contentUrl == url })
+        // Mirror the server's rule locally: Watched evicts from Watch Later,
+        // or that tab keeps showing the title until the next refresh.
+        if (kind == UserListKind.WATCHED) {
+            store(
+                UserListKind.WATCH_LATER,
+                cached(UserListKind.WATCH_LATER).filterNot { it.contentUrl == url },
+            )
+        }
+        client.add(kind, item)
+        Unit
+    }
+
+    suspend fun remove(kind: UserListKind, contentUrl: String) = withContext(Dispatchers.IO) {
+        store(kind, cached(kind).filterNot { it.contentUrl == contentUrl })
+        client.remove(kind, contentUrl)
+        Unit
+    }
+
+    /** Sign-out must not leave another account's lists on the box. */
+    fun clear() {
+        prefs.edit().clear().apply()
+    }
+
+    private companion object {
+        const val FILE = "sozo_user_lists"
+    }
+}

--- a/app/src/main/java/com/saikou/sozo_tv/di/networkModule.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/di/networkModule.kt
@@ -6,7 +6,9 @@ import com.saikou.sozo_tv.BuildConfig
 import com.saikou.sozo_tv.data.local.pref.DeviceSessionStore
 import com.saikou.sozo_tv.data.extensions.ExtensionEngine
 import com.saikou.sozo_tv.data.remote.device.DeviceAuthClient
+import com.saikou.sozo_tv.data.remote.lists.UserListsClient
 import com.saikou.sozo_tv.data.repository.DeviceAuthRepository
+import com.saikou.sozo_tv.data.repository.UserListsRepository
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.android.ext.koin.androidContext
@@ -32,6 +34,20 @@ val NetworkModule = module {
         )
     }
     single { DeviceAuthRepository(client = get(), store = get()) }
+
+    // Curated lists (Watch Later / Watched) — the first authenticated API the TV
+    // calls. Shares the auth client (platform TLS, no body logging) because it
+    // sends a bearer token; the token is read per-request through
+    // DeviceAuthRepository so refreshes are picked up mid-session.
+    single {
+        UserListsClient(
+            okHttpClient = get(named("authOkHttp")),
+            gson = get(),
+            baseUrl = BuildConfig.SOZO_API_BASE_URL,
+            tokenProvider = { get<DeviceAuthRepository>().accessToken() },
+        )
+    }
+    single { UserListsRepository(context = androidContext(), client = get()) }
 
 }
 

--- a/app/src/main/java/com/saikou/sozo_tv/domain/repository/SearchRepository.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/domain/repository/SearchRepository.kt
@@ -5,4 +5,11 @@ import com.saikou.sozo_tv.domain.model.SearchModel
 interface SearchRepository {
     suspend fun searchAnime(query: String): Result<List<SearchModel>>
     suspend fun searchMovie(query: String): Result<List<SearchModel>>
+
+    /**
+     * Search every installed source instead of just the active one. Bounded and
+     * failure-tolerant in the engine, so this returns whatever answered in time
+     * rather than failing when one source is down.
+     */
+    suspend fun searchAllSources(query: String): Result<List<SearchModel>>
 }

--- a/app/src/main/java/com/saikou/sozo_tv/engine/server/ServerHost.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/engine/server/ServerHost.kt
@@ -285,6 +285,13 @@ class ServerHost(
                 if (s.optBoolean("useLocalProxy", false)) put("useLocalProxy", true)
                 s.optJSONObject("localProxy")?.let { put("localProxy", it) }
                 s.optJSONObject("requestTransform")?.let { put("requestTransform", it) }
+                // Headless-WebView sniff directive (embed pages whose manifest is
+                // only produced by the page's own JS) — forward raw, per source
+                // or inherited from the media level.
+                if (s.optBoolean("useWebViewSniff", o.optBoolean("useWebViewSniff", false))) {
+                    put("useWebViewSniff", true)
+                }
+                (s.optJSONObject("sniff") ?: o.optJSONObject("sniff"))?.let { put("sniff", it) }
             })
         }
         val subIn = o.optJSONArray("subtitles") ?: JSONArray()
@@ -304,6 +311,11 @@ class ServerHost(
             put("headers", o.optJSONObject("headers") ?: JSONObject())
             put("videoSources", srcOut)
             put("subtitles", subOut)
+            // Media-level capability flag. Forwarded as well as per-source so a
+            // provider that declares it once for the whole payload still reaches
+            // ExtParser's media-level fallback.
+            if (o.optBoolean("useWebViewSniff", false)) put("useWebViewSniff", true)
+            o.optJSONObject("sniff")?.let { put("sniff", it) }
             // Forward the seek-preview thumbnails (VTT sprite sheet). soplay emits it as a bare
             // VTT url String or a {url,type,...} object — pass it through raw so downstream can read it.
             o.opt("thumbnails")?.takeIf { it != JSONObject.NULL }?.let { put("thumbnails", it) }

--- a/app/src/main/java/com/saikou/sozo_tv/parser/models/ShowResponse.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/parser/models/ShowResponse.kt
@@ -29,6 +29,8 @@ data class VideoOption(
     var useLocalProxy: Boolean = false,
     var localProxy: String? = null,
     var requestTransform: String? = null,
+    var useWebViewSniff: Boolean = false,
+    var sniff: String? = null,
 )
 
 

--- a/app/src/main/java/com/saikou/sozo_tv/parser/sources/ExtensionParser.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/parser/sources/ExtensionParser.kt
@@ -106,6 +106,8 @@ class ExtensionParser : BaseParser() {
                 useLocalProxy = s.useLocalProxy,
                 localProxy = s.localProxy,
                 requestTransform = s.requestTransform,
+                useWebViewSniff = s.useWebViewSniff,
+                sniff = s.sniff,
             )
         }
     }

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
@@ -229,7 +229,12 @@ class SeriesPlayerScreen : Fragment() {
 
     private fun showNextEpisodeCountdown() {
         binding.apply {
-            if (!LocalData.isHistoryItemClicked && !countdownShown) {
+            // Runs for history playback too. The history intent carries the same
+            // (page, epIndex) the normal path uses, so `episodeList` is fully
+            // populated either way — there was never a data reason to stop the
+            // run at one episode, and stopping it is what users hit as "History
+            // won't continue to the next episode".
+            if (!countdownShown) {
                 val nextEpisodeIndex = model.currentEpIndex + 1
                 if (nextEpisodeIndex < episodeList.size) {
                     countdownShown = true
@@ -339,10 +344,10 @@ class SeriesPlayerScreen : Fragment() {
             override fun onPlaybackStateChanged(playbackState: Int) {
                 when (playbackState) {
                     Player.STATE_READY -> {
-                        if (!LocalData.isHistoryItemClicked) {
-                            resetCountdownState()
-                            startProgressTracking()
-                        }
+                        // Unconditional: the countdown/auto-advance tracker is what
+                        // drives "next episode", and history playback needs it too.
+                        resetCountdownState()
+                        startProgressTracking()
 
                         val dur = player.duration
                         if (::skipIntroView.isInitialized) {
@@ -370,7 +375,7 @@ class SeriesPlayerScreen : Fragment() {
                     }
 
                     Player.STATE_ENDED -> {
-                        if (!LocalData.isHistoryItemClicked && player.duration > 0) {
+                        if (player.duration > 0) {
                             stopProgressTracking()
                             if (!isCountdownActive) playNextEpisodeAutomatically()
                         }
@@ -587,15 +592,13 @@ class SeriesPlayerScreen : Fragment() {
 
             val lastPosition = model.getWatchedHistoryEntity?.lastPosition ?: 0L
 
-            if (LocalData.isHistoryItemClicked) {
-                binding.pvPlayer.controller.binding.exoNextContainer.gone()
-                binding.pvPlayer.controller.binding.exoPrevContainer.gone()
-                binding.pvPlayer.controller.binding.epListContainer.gone()
-            } else {
-                binding.pvPlayer.controller.binding.exoNextContainer.visible()
-                binding.pvPlayer.controller.binding.exoPrevContainer.visible()
-                binding.pvPlayer.controller.binding.epListContainer.visible()
-            }
+            // Episode controls are shown for history playback as well. Hiding
+            // them was the second half of the same restriction: a user who
+            // resumed from History could neither auto-advance nor reach the
+            // episode list, so a resumed show was a dead end.
+            binding.pvPlayer.controller.binding.exoNextContainer.visible()
+            binding.pvPlayer.controller.binding.exoPrevContainer.visible()
+            binding.pvPlayer.controller.binding.epListContainer.visible()
 
             setupOrUpdatePreviewThumbnails(vod.thumbnail, vod.header)
 

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/search/SearchScreen.kt
@@ -67,6 +67,7 @@ class SearchScreen : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         setupRecyclerView()
         setupCustomKeyboard()
+        setupSearchScopeToggle()
         initializeSearch()
         observeViewModel()
         setupTVFocusHandling()
@@ -463,14 +464,34 @@ class SearchScreen : Fragment() {
         requireActivity().startActivity(intent)
     }
 
+    /** false = active source only (default), true = every installed source. */
+    private var searchAllSources = false
+
+    private fun setupSearchScopeToggle() {
+        binding.searchScopeToggle.setOnClickListener {
+            searchAllSources = !searchAllSources
+            binding.searchScopeToggle.text =
+                if (searchAllSources) "All sources" else "This source"
+            // Re-run the text already on screen so flipping the scope shows its
+            // effect immediately instead of waiting for the next keystroke.
+            val current = lastSearchQuery.ifEmpty { binding.searchEdt.text?.toString().orEmpty() }
+            if (current.trim().length >= 2) performSearchImmediate(current)
+        }
+    }
+
     private fun performSearchImmediate(query: String) {
         if (query.isNotEmpty()) {
-            // Search the currently-selected extension provider directly, so results
-            // (and their posters) come from that source.
-            model.searchAnime(query.trim())
-            searchAdapter.setQueryText(query.trim())
+            val q = query.trim()
+            // Active provider by default; "All sources" fans out across every
+            // installed one (bounded + failure-tolerant in ExtensionEngine).
+            if (searchAllSources) model.searchAllSources(q) else model.searchAnime(q)
+            searchAdapter.setQueryText(q)
             binding.recommendationsTitle.visibility = View.VISIBLE
-            binding.recommendationsTitle.text = "Search Results for \"$query\""
+            binding.recommendationsTitle.text = if (searchAllSources) {
+                "All sources — \"$query\""
+            } else {
+                "Search Results for \"$query\""
+            }
         }
     }
 

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/PlayAnimeViewModel.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/PlayAnimeViewModel.kt
@@ -218,14 +218,24 @@ class PlayAnimeViewModel(
                 var headers = option.headers
                 var mime = option.mimeTypes.ifEmpty { MimeTypes.APPLICATION_M3U8 }
 
-                // Cloud providers (e.g. asilmedia) resolve to an HTML content page as videoUrl —
-                // ExoPlayer can't parse a page. Sniff the real .m3u8/.mp4 out of a headless WebView
-                // (its JS builds the signed stream url) and play THAT with the captured headers.
-                if (com.saikou.sozo_tv.engine.player.WebViewStreamExtractor.needsExtraction(url)) {
+                // Some sources resolve to an HTML page, not a stream — ExoPlayer can't parse a
+                // page. Sniff the real .m3u8/.mp4 out of a headless WebView (the page's own JS
+                // builds the signed url) and play THAT with the captured headers.
+                //
+                // Two ways in, and the ORDER matters. The server-set `useWebViewSniff` flag is
+                // authoritative: it is how a backend declares "this source needs a browser"
+                // without the app knowing which site it is, so adding another such provider
+                // never ships an app update. `needsExtraction` stays only as the legacy
+                // heuristic for sources that predate the flag (it sniffs the URL for
+                // .html/.php/-style paths and cannot see an extensionless /embed/<token>).
+                if (option.useWebViewSniff ||
+                    com.saikou.sozo_tv.engine.player.WebViewStreamExtractor.needsExtraction(url)
+                ) {
                     val sniffed = com.saikou.sozo_tv.engine.player.WebViewStreamExtractor.extract(
                         context = com.saikou.sozo_tv.app.MyApp.context,
                         pageUrl = url,
                         pageHeaders = option.headers,
+                        timeoutMs = sniffTimeoutMs(option.sniff),
                     )
                     if (sniffed != null) {
                         url = sniffed.url
@@ -318,6 +328,22 @@ class PlayAnimeViewModel(
                 )
             }
         }
+    }
+
+    /**
+     * `sniff.timeoutMs` from the server's directive, clamped.
+     *
+     * Clamped rather than trusted: this value decides how long playback sits on a
+     * spinner, and a bad/hostile payload must not be able to hang the player. The
+     * default matches WebViewStreamExtractor's own.
+     */
+    private fun sniffTimeoutMs(sniffJson: String?): Long {
+        val fallback = 20_000L
+        if (sniffJson.isNullOrBlank()) return fallback
+        return runCatching {
+            val v = org.json.JSONObject(sniffJson).optLong("timeoutMs", fallback)
+            v.coerceIn(5_000L, 45_000L)
+        }.getOrDefault(fallback)
     }
 
     private fun asException(t: Throwable): Exception = (t as? Exception) ?: Exception(t)

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/SearchViewModel.kt
@@ -44,6 +44,34 @@ class SearchViewModel(
         }
     }
 
+    /**
+     * "All sources" search. Kept separate from [searchAnime]/[searchMovie]
+     * rather than folded in behind a flag, because the screen has to be able to
+     * re-run the SAME query in the other mode — sharing `lastQuery` de-dup with
+     * them would swallow that second run as a no-op.
+     */
+    fun searchAllSources(query: String) {
+        if (lastGlobalQuery == query) return
+        viewModelScope.launch {
+            _loading.value = true
+            repo.searchAllSources(query)
+                .onSuccess {
+                    _loading.value = false
+                    _searchResults.value = it
+                    lastGlobalQuery = query
+                    // Let a later single-source search of the same text still run.
+                    lastQuery = ""
+                }
+                .onFailure {
+                    _loading.value = false
+                    errorData.value = it.message
+                    _searchResults.value = emptyList()
+                }
+        }
+    }
+
+    private var lastGlobalQuery = ""
+
     fun searchMovie(query: String) {
         if (lastQuery != query) {
             viewModelScope.launch {

--- a/app/src/main/java/com/saikou/sozo_tv/utils/CustomTVKeyboard.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/utils/CustomTVKeyboard.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
 import com.saikou.sozo_tv.R
@@ -56,6 +57,53 @@ class CustomTVKeyboard @JvmOverloads constructor(
             updateKeyFocus(it)
         }
 
+        setupSymbols()
+    }
+
+    /**
+     * Symbol keys carry no ids — each one is bound from its OWN text, so adding a
+     * symbol to `custom_tv_keyboard.xml` needs no change here. The page toggle
+     * swaps which grid is visible and moves focus with it, because on a remote a
+     * hidden-but-focused key strands the D-pad with nothing highlighted.
+     */
+    private fun setupSymbols() {
+        val letters = findViewById<View>(R.id.letters_page) ?: return
+        val symbols = findViewById<View>(R.id.symbols_page) ?: return
+        val toggle = findViewById<TextView>(R.id.key_toggle) ?: return
+
+        bindTextKeys(symbols)
+
+        toggle.setOnClickListener {
+            val showSymbols = symbols.visibility != View.VISIBLE
+            symbols.visibility = if (showSymbols) View.VISIBLE else View.GONE
+            letters.visibility = if (showSymbols) View.GONE else View.VISIBLE
+            toggle.text = if (showSymbols) LABEL_LETTERS else LABEL_SYMBOLS
+            updateKeyFocus(it)
+            (if (showSymbols) symbols else letters).let(::focusFirstKey)
+        }
+    }
+
+    /** Every TextView under [root] emits its own text when clicked. */
+    private fun bindTextKeys(root: View) {
+        forEachKey(root) { key ->
+            key.setOnClickListener {
+                onKeyClickListener?.invoke(key.text.toString())
+                updateKeyFocus(it)
+            }
+        }
+    }
+
+    private fun focusFirstKey(root: View) {
+        var first: TextView? = null
+        forEachKey(root) { if (first == null) first = it }
+        first?.requestFocus()
+    }
+
+    private fun forEachKey(root: View, action: (TextView) -> Unit) {
+        when (root) {
+            is TextView -> action(root)
+            is ViewGroup -> for (i in 0 until root.childCount) forEachKey(root.getChildAt(i), action)
+        }
     }
 
     private fun updateKeyFocus(clickedView: View) {
@@ -83,5 +131,12 @@ class CustomTVKeyboard @JvmOverloads constructor(
 
     fun setOnClearClickListener(listener: () -> Unit) {
         onClearClickListener = listener
+    }
+
+    private companion object {
+        // NOT "?123": a value starting with '?' is read by AAPT as a theme
+        // attribute reference (?attr/123) and fails resource linking.
+        const val LABEL_SYMBOLS = "123#"
+        const val LABEL_LETTERS = "ABC"
     }
 }

--- a/app/src/main/res/layout/custom_tv_keyboard.xml
+++ b/app/src/main/res/layout/custom_tv_keyboard.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  TV search keyboard.
+
+  QWERTY, not alphabetical: the muscle memory every user already has beats
+  A-Z ordering on a D-pad, where each extra row/column traversal is a click.
+
+  The symbols page exists because search matches titles EXACTLY, and titles
+  carry apostrophes, colons and hyphens. Without it those shows are unreachable.
+
+  Letter/digit keys keep their original @id/key_<char> names, so the id-based
+  wiring in CustomTVKeyboard.kt keeps working unchanged. Symbol keys carry NO
+  id on purpose — they are bound by walking the container and reading each
+  key's own text, so adding a symbol here needs no Kotlin change.
+-->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -8,313 +21,538 @@
     android:padding="4dp">
 
     <LinearLayout
+        android:id="@+id/letters_page"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_marginBottom="4dp">
-
-        <!-- Increased key size from 32dp to 38dp for better TV visibility -->
-        <TextView
-            android:id="@+id/key_a"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="a" />
-
-        <TextView
-            android:id="@+id/key_b"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="b" />
-
-        <TextView
-            android:id="@+id/key_c"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="c" />
-
-        <TextView
-            android:id="@+id/key_d"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="d" />
-
-        <TextView
-            android:id="@+id/key_e"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="e" />
-
-        <TextView
-            android:id="@+id/key_f"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="f" />
-
-    </LinearLayout>
+        android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:layout_gravity="center_horizontal"
         android:layout_marginBottom="4dp">
-
-        <TextView
-            android:id="@+id/key_g"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="g" />
-
-        <TextView
-            android:id="@+id/key_h"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="h" />
-
-        <TextView
-            android:id="@+id/key_i"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="i" />
-
-        <TextView
-            android:id="@+id/key_j"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="j" />
-
-        <TextView
-            android:id="@+id/key_k"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="k" />
-
-        <TextView
-            android:id="@+id/key_l"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="l" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_marginBottom="4dp">
-
-        <TextView
-            android:id="@+id/key_m"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="m" />
-
-        <TextView
-            android:id="@+id/key_n"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="n" />
-
-        <TextView
-            android:id="@+id/key_o"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="o" />
-
-        <TextView
-            android:id="@+id/key_p"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="p" />
-
-        <TextView
-            android:id="@+id/key_q"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="q" />
-
-        <TextView
-            android:id="@+id/key_r"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="r" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_marginBottom="4dp">
-
-        <TextView
-            android:id="@+id/key_s"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="s" />
-
-        <TextView
-            android:id="@+id/key_t"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="t" />
-
-        <TextView
-            android:id="@+id/key_u"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="u" />
-
-        <TextView
-            android:id="@+id/key_v"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="v" />
-
-        <TextView
-            android:id="@+id/key_w"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="w" />
-
-        <TextView
-            android:id="@+id/key_x"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="x" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_marginBottom="4dp">
-
-        <TextView
-            android:id="@+id/key_y"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="y" />
-
-        <TextView
-            android:id="@+id/key_z"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="z" />
 
         <TextView
             android:id="@+id/key_1"
             style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
             android:layout_margin="2dp"
             android:textSize="14sp"
             android:text="1" />
-
         <TextView
             android:id="@+id/key_2"
             style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
             android:layout_margin="2dp"
             android:textSize="14sp"
             android:text="2" />
-
         <TextView
             android:id="@+id/key_3"
             style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
             android:layout_margin="2dp"
             android:textSize="14sp"
             android:text="3" />
-
         <TextView
             android:id="@+id/key_4"
             style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
             android:layout_margin="2dp"
             android:textSize="14sp"
             android:text="4" />
+        <TextView
+            android:id="@+id/key_5"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="5" />
+        <TextView
+            android:id="@+id/key_6"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="6" />
+        <TextView
+            android:id="@+id/key_7"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="7" />
+        <TextView
+            android:id="@+id/key_8"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="8" />
+        <TextView
+            android:id="@+id/key_9"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="9" />
+        <TextView
+            android:id="@+id/key_0"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="0" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="4dp">
+
+        <TextView
+            android:id="@+id/key_q"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="q" />
+        <TextView
+            android:id="@+id/key_w"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="w" />
+        <TextView
+            android:id="@+id/key_e"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="e" />
+        <TextView
+            android:id="@+id/key_r"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="r" />
+        <TextView
+            android:id="@+id/key_t"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="t" />
+        <TextView
+            android:id="@+id/key_y"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="y" />
+        <TextView
+            android:id="@+id/key_u"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="u" />
+        <TextView
+            android:id="@+id/key_i"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="i" />
+        <TextView
+            android:id="@+id/key_o"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="o" />
+        <TextView
+            android:id="@+id/key_p"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="p" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="4dp">
+
+        <TextView
+            android:id="@+id/key_a"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="a" />
+        <TextView
+            android:id="@+id/key_s"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="s" />
+        <TextView
+            android:id="@+id/key_d"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="d" />
+        <TextView
+            android:id="@+id/key_f"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="f" />
+        <TextView
+            android:id="@+id/key_g"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="g" />
+        <TextView
+            android:id="@+id/key_h"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="h" />
+        <TextView
+            android:id="@+id/key_j"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="j" />
+        <TextView
+            android:id="@+id/key_k"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="k" />
+        <TextView
+            android:id="@+id/key_l"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="l" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="4dp">
+
+        <TextView
+            android:id="@+id/key_z"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="z" />
+        <TextView
+            android:id="@+id/key_x"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="x" />
+        <TextView
+            android:id="@+id/key_c"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="c" />
+        <TextView
+            android:id="@+id/key_v"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="v" />
+        <TextView
+            android:id="@+id/key_b"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="b" />
+        <TextView
+            android:id="@+id/key_n"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="n" />
+        <TextView
+            android:id="@+id/key_m"
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="m" />
+    </LinearLayout>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/symbols_page"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="4dp">
+
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="&#39;" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="&quot;" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text=":" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text=";" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="-" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="_" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="." />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="," />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="4dp">
+
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="!" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="?" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="(" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text=")" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="[" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="]" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="&amp;" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="#" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="4dp">
+
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="@" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="+" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="*" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="=" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="%" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="$" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="/" />
+        <TextView
+            style="@style/KeyboardKey"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_margin="2dp"
+            android:textSize="14sp"
+            android:text="~" />
+    </LinearLayout>
 
     </LinearLayout>
 
@@ -322,90 +560,32 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:layout_marginBottom="6dp">
+        android:layout_gravity="center_horizontal">
 
         <TextView
-            android:id="@+id/key_5"
+            android:id="@+id/key_toggle"
             style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
+            android:layout_width="64dp"
+            android:layout_height="36dp"
             android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="5" />
-
-        <TextView
-            android:id="@+id/key_6"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="6" />
-
-        <TextView
-            android:id="@+id/key_7"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="7" />
-
-        <TextView
-            android:id="@+id/key_8"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="8" />
-
-        <TextView
-            android:id="@+id/key_9"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="9" />
-
-        <TextView
-            android:id="@+id/key_0"
-            style="@style/KeyboardKey"
-            android:layout_width="38dp"
-            android:layout_height="38dp"
-            android:layout_margin="2dp"
-            android:textSize="14sp"
-            android:text="0" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <!-- Increased space bar and backspace button sizes for better TV usability -->
+            android:textSize="13sp"
+            android:text="123#" />
         <TextView
             android:id="@+id/key_space"
             style="@style/KeyboardKey"
-            android:text="SPACE"
-            android:layout_width="160dp"
-            android:layout_height="38dp"
+            android:layout_width="152dp"
+            android:layout_height="36dp"
             android:layout_margin="2dp"
-            android:gravity="center"
-            android:textSize="12sp"
-            android:textAllCaps="true" />
-
+            android:textSize="13sp"
+            android:text="SPACE" />
         <TextView
             android:id="@+id/key_backspace"
-            style="@style/KeyboardControlKey"
-            android:text="⌫"
-            android:layout_width="80dp"
-            android:layout_height="38dp"
+            style="@style/KeyboardKey"
+            android:layout_width="64dp"
+            android:layout_height="36dp"
             android:layout_margin="2dp"
-            android:textSize="14sp" />
-
+            android:textSize="13sp"
+            android:text="DEL" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/search_screen.xml
+++ b/app/src/main/res/layout/search_screen.xml
@@ -83,14 +83,38 @@
                 android:layout_weight="1.7"
                 android:orientation="vertical">
 
-                <TextView
-                    android:id="@+id/recommendationsTitle"
-                    style="@style/NetflixTitle"
-                    android:layout_width="wrap_content"
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="12dp"
-                    android:text="Your Search Recommendations"
-                    android:textSize="18sp" />
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/recommendationsTitle"
+                        style="@style/NetflixTitle"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Your Search Recommendations"
+                        android:textSize="18sp" />
+
+                    <!--
+                      Scope toggle: active source (default) <-> every installed
+                      source. Focusable so the D-pad can reach it from the grid.
+                    -->
+                    <TextView
+                        android:id="@+id/searchScopeToggle"
+                        style="@style/KeyboardKey"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:paddingHorizontal="14dp"
+                        android:paddingVertical="6dp"
+                        android:text="This source"
+                        android:textSize="13sp" />
+
+                </LinearLayout>
 
                 <androidx.leanback.widget.VerticalGridView
                     android:id="@+id/vgvSearch"


### PR DESCRIPTION
Based on `feat/tv-qr-device-login` rather than `main` — that branch is 541 commits behind, so a PR against it would be unreadable.

Four independent commits.

## 1. History playback continues (`18bb5b8`)

Opening a show from History hid next/prev and the episode list, skipped the countdown and never auto-advanced — a resumed show was a dead end at one episode.

There was **never a data reason** for the restriction: the History intent carries the same `(page, epIndex)` the normal path uses, so `episodeList` is fully populated either way. Going back still returns to History, which is correct.

## 2. QWERTY keyboard + symbols page (`66e332b`)

Alphabetical ordering cost extra D-pad traversals on every key, and there was **no way to type an apostrophe, colon or hyphen at all** — search matches titles exactly, so those shows were unreachable.

- Rows: `1234567890` / `qwertyuiop` / `asdfghjkl` / `zxcvbnm`
- Symbols: `' " : ; - _ . ,` / `! ? ( ) [ ] & #` / `@ + * = % $ / ~`

Letter/digit keys keep their `@id/key_<char>` names, so the existing id-based wiring is untouched. Symbol keys carry **no id** — they're bound by reading each key's own text, so adding a symbol needs no Kotlin change. The page toggle moves focus with it; a hidden-but-focused key strands the D-pad.

> Label is `123#`, not `?123`: a value starting with `?` is read by AAPT as a theme attribute reference and fails resource linking.

⚠️ The keyboard went from 6 columns to 10 (36dp keys). The container is flexible (`match_parent`, weight 0.85) but **this needs a look on a real panel** — it's the one visual risk here.

## 3. "All sources" search (`818abee`)

Fans out across all three groups instead of only the active provider, behind a focusable toggle next to the results title.

Three bounds, all load-bearing — a CloudStream repo alone can install dozens of providers:
- at most **12** providers queried
- each with its **own** 12s timeout, so one stalled mirror costs its own slot and nothing else
- a throwing source is dropped rather than failing the whole search

Active provider is queried first so its hits lead. Deduped on `(provider, contentUrl)` — the same title on two sources is two separately playable entries, so only exact repeats collapse.

## 4. Sniff flag + curated-list data layer (`cc77986`)

**Sniff flag.** Threads `useWebViewSniff` / `sniff` from the media payload to the player. The server-set flag is checked **before** the legacy `needsExtraction` heuristic, which only matches `.html`/`.php`-style paths and cannot see an extensionless `/embed/<token>`. A backend can now declare "this source needs a browser" without the app knowing which site it is. `sniff.timeoutMs` is clamped to 5–45s — it decides how long playback sits on a spinner, so a bad payload must not hang the player.

**Lists data layer.** `UserListsClient` is the TV's **first authenticated API surface** — until now the device session minted and rotated an access token that nothing ever spent. The token is read per-request rather than captured once, because it lives 15 minutes and is refreshed transparently. Uses the auth OkHttp client (platform TLS, no body logging): the content client trusts any certificate and must never carry a bearer token.

Cache is SharedPreferences JSON, not Room — new entities mean a schema version bump, and a missing migration is a crash-on-launch for every existing install.

Pairs with sozo-backend#1.

## Verification

`assembleDebug` succeeds. Nothing was run on a device or emulator.

**Still missing on TV:** the list *screens* — detail-page buttons (`MovieDetailsAdapter` + its layout) and sections in `BookmarkScreen`. The data layer is done and compiling, so the TV can already fetch lists the phone created; it just has no UI to show or edit them yet.