### PR TITLE
Sync watch history with the signed-in account

### DIFF
--- a/app/src/main/java/com/saikou/sozo_tv/data/remote/history/WatchHistorySyncClient.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/remote/history/WatchHistorySyncClient.kt
@@ -1,0 +1,122 @@
+package com.saikou.sozo_tv.data.remote.history
+
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import com.saikou.sozo_tv.data.remote.device.ApiResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+/**
+ * One history row on the wire. The field names are the server's contract and
+ * are shared verbatim with the Flutter client - renaming one here desyncs the
+ * two apps into separate rows for the same episode.
+ *
+ * [extra] carries whatever a platform stores beyond the shared shape (the TV's
+ * Room row has a dozen such fields) and comes back untouched, so a device gets
+ * its own full record rather than a lossy projection of it.
+ */
+data class HistorySyncItem(
+    val provider: String,
+    val contentUrl: String? = null,
+    val contentId: String? = null,
+    val title: String? = null,
+    val thumbnail: String? = null,
+    val isSerial: Boolean = false,
+    val episodeIndex: Int? = null,
+    val episodeNumber: Int? = null,
+    val episodeLabel: String? = null,
+    val positionMs: Long = 0,
+    val durationMs: Long = 0,
+    val extra: Map<String, Any?>? = null,
+    val watchedAt: String? = null,
+    val deletedAt: String? = null,
+    /** Server-assigned identity. Sent back as-is; never invented by the client. */
+    val key: String? = null,
+)
+
+data class HistorySyncResult(
+    val items: List<HistorySyncItem>,
+    /** Server clock. Becomes the next request's `since`, so client skew cannot lose rows. */
+    val serverTime: String?,
+)
+
+private data class SyncRequest(
+    val items: List<HistorySyncItem>,
+    val since: String?,
+)
+
+private data class SyncResponse(
+    val items: List<HistorySyncItem>? = null,
+    val serverTime: String? = null,
+)
+
+private data class ApiMessage(@SerializedName("message") val message: String?)
+
+/**
+ * Transport for `/auth/history/sync` - push and pull in one round trip.
+ *
+ * Shares the `authOkHttp` client with device sign-in for the same reason the
+ * lists client does: this call carries a bearer token, and the app's content
+ * client trusts any certificate.
+ */
+class WatchHistorySyncClient(
+    private val okHttpClient: OkHttpClient,
+    private val gson: Gson,
+    private val baseUrl: String,
+    private val tokenProvider: suspend () -> String?,
+) {
+
+    /**
+     * Sends [items] and returns everything changed elsewhere since [since].
+     *
+     * An empty [items] is a normal pull, not a special case - a device with no
+     * local changes still wants the other devices' progress.
+     */
+    suspend fun sync(items: List<HistorySyncItem>, since: String?): ApiResult<HistorySyncResult> =
+        withContext(Dispatchers.IO) {
+            // No token => signed out. Reported as 401 so callers branch on the
+            // code rather than on message text.
+            val token = runCatching { tokenProvider() }.getOrNull()
+                ?: return@withContext ApiResult.Http(401, "Not signed in", null)
+
+            try {
+                val payload = gson.toJson(SyncRequest(items, since)).toRequestBody(JSON)
+                val request = Request.Builder()
+                    .url("${baseUrl.trimEnd('/')}$PATH")
+                    .addHeader("Authorization", "Bearer $token")
+                    .addHeader("Accept", "application/json")
+                    .addHeader("Content-Type", "application/json")
+                    .post(payload)
+                    .build()
+
+                okHttpClient.newCall(request).execute().use { resp ->
+                    val raw = resp.body.string()
+                    if (!resp.isSuccessful) {
+                        val msg = runCatching {
+                            gson.fromJson(raw, ApiMessage::class.java)?.message
+                        }.getOrNull()
+                        return@use ApiResult.Http(
+                            resp.code, msg, resp.header("Retry-After")?.trim()?.toIntOrNull(),
+                        )
+                    }
+                    val parsed = runCatching { gson.fromJson(raw, SyncResponse::class.java) }
+                        .getOrNull()
+                        ?: return@use ApiResult.Http(resp.code, "Empty response", null)
+                    ApiResult.Ok(
+                        HistorySyncResult(parsed.items.orEmpty(), parsed.serverTime)
+                    )
+                }
+            } catch (t: Throwable) {
+                ApiResult.Network(t)
+            }
+        }
+
+    private companion object {
+        val JSON = "application/json; charset=utf-8".toMediaType()
+        const val PATH = "/auth/history/sync"
+    }
+}

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/WatchHistorySyncRepository.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/WatchHistorySyncRepository.kt
@@ -1,0 +1,300 @@
+package com.saikou.sozo_tv.data.repository
+
+import android.content.Context
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.saikou.sozo_tv.data.local.entity.WatchHistoryEntity
+import com.saikou.sozo_tv.data.remote.device.ApiResult
+import com.saikou.sozo_tv.data.remote.history.HistorySyncItem
+import com.saikou.sozo_tv.data.remote.history.WatchHistorySyncClient
+import com.saikou.sozo_tv.domain.repository.WatchHistoryRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Keeps this box's watch history in step with the signed-in account.
+ *
+ * WHAT ACTUALLY SYNCS, and why it is not simply "everything":
+ *
+ * A TV row is a Room record keyed by `session` - a provider-specific handle for
+ * one episode stream. The phone has no such handle, so a phone row cannot be
+ * turned into a playable TV row. Pretending otherwise would fill the History
+ * screen with entries that open nothing.
+ *
+ * So the split is honest:
+ *   - TV -> TV     full rows. The whole Room record rides along in `extra` and
+ *                  comes back intact, so a second box shows real, playable history.
+ *   - TV <-> phone resume position on content both can name. If the phone got
+ *                  further into an episode this box already knows about, this
+ *                  box picks up there. A phone-only title is remembered on the
+ *                  server for the phone, and simply not shown here.
+ *
+ * Deletes travel as tombstones. Room's DAO removes rows outright, so a delete
+ * leaves no trace to upload - without recording one here, the next sync would
+ * see the server's copy as "new" and put the row straight back.
+ */
+class WatchHistorySyncRepository(
+    context: Context,
+    private val client: WatchHistorySyncClient,
+    private val local: WatchHistoryRepository,
+    private val gson: Gson = Gson(),
+) {
+
+    private val prefs = context.getSharedPreferences(FILE, Context.MODE_PRIVATE)
+    private val mutex = Mutex()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val tombstoneType = object : TypeToken<Map<String, String>>() {}.type
+
+    /** True once the account has ever synced here; drives "sync is on" in the UI. */
+    val hasSynced: Boolean get() = prefs.getString(KEY_CURSOR, null) != null
+
+    // ─── public API ──────────────────────────────────────────────────────────
+
+    /**
+     * Push local changes, pull everyone else's, write the result to Room.
+     *
+     * Serialised by [mutex]: playback-end and screen-open can both land on this
+     * at once, and two interleaved runs would push the same rows twice and race
+     * over the cursor.
+     *
+     * Returns false when nothing could be done (signed out, or offline). Callers
+     * treat that as "try again later", never as an error worth showing.
+     */
+    suspend fun sync(): Boolean = mutex.withLock {
+        withContext(Dispatchers.IO) {
+            val cursor = prefs.getString(KEY_CURSOR, null)
+            val tombstones = readTombstones()
+
+            val outgoing = buildList {
+                // Only rows touched since the last successful push. A full
+                // upload every time would rewrite the whole server list and
+                // wake every other device for nothing.
+                val floor = prefs.getLong(KEY_PUSHED_AT, 0L)
+                local.getAllHistory()
+                    .filter { it.watchedAt > floor }
+                    .forEach { add(it.toSyncItem()) }
+                tombstones.forEach { (key, deletedAt) ->
+                    add(HistorySyncItem(provider = "", key = key, deletedAt = deletedAt, watchedAt = deletedAt))
+                }
+            }
+
+            when (val result = client.sync(outgoing, cursor)) {
+                is ApiResult.Ok -> {
+                    applyRemote(result.body.items)
+                    prefs.edit()
+                        .putString(KEY_CURSOR, result.body.serverTime ?: cursor)
+                        // Stamped from the rows we just sent, not from "now":
+                        // a row written while the request was in flight must
+                        // still be picked up next time.
+                        .putLong(KEY_PUSHED_AT, outgoing.maxOfOrNull { parseIso(it.watchedAt) } ?: prefs.getLong(KEY_PUSHED_AT, 0L))
+                        .remove(KEY_TOMBSTONES)
+                        .apply()
+                    true
+                }
+                // 401 means signed out. Keeping the tombstones is deliberate:
+                // they must survive until a sync actually accepts them.
+                else -> false
+            }
+        }
+    }
+
+    /**
+     * Fire-and-forget sync on the repository's own scope.
+     *
+     * For callers that are about to tear themselves down - a sign-in hand-off
+     * relaunches the activity in the same handler, and a coroutine on its scope
+     * would be cancelled before the request left the box.
+     */
+    fun syncAsync(): Job = scope.launch { runCatching { sync() } }
+
+    /** Records a delete so it can travel. Call BEFORE removing the Room row. */
+    suspend fun rememberDeleted(entity: WatchHistoryEntity) {
+        val key = entity.syncKey() ?: return
+        mutex.withLock { writeTombstone(key) }
+    }
+
+    /** Records a full clear. Call BEFORE clearing Room. */
+    suspend fun rememberClearedAll() {
+        val keys = local.getAllHistory().mapNotNull { it.syncKey() }
+        if (keys.isEmpty()) return
+        mutex.withLock {
+            val now = nowIso()
+            writeTombstones(readTombstones() + keys.associateWith { now })
+        }
+    }
+
+    /** Sign-out must not leave one account's cursor pointing at another's history. */
+    fun clear() = prefs.edit().clear().apply()
+
+    // ─── applying the server's answer ────────────────────────────────────────
+
+    private suspend fun applyRemote(items: List<HistorySyncItem>) {
+        for (item in items) {
+            val key = item.key ?: continue
+            val session = item.extra?.get(EXTRA_SESSION) as? String
+
+            if (item.deletedAt != null) {
+                // Deleted elsewhere. Only rows this box can name are removable.
+                session?.let { local.removeHistory(it) }
+                continue
+            }
+
+            val existing = session?.let { local.getWatchHistoryById(it) }
+                ?: findByKey(key)
+
+            when {
+                // A row this box already has: take the newer position only.
+                existing != null -> {
+                    if (item.watchedAtMillis() > existing.watchedAt) {
+                        local.addHistory(
+                            existing.copy(
+                                lastPosition = item.positionMs,
+                                totalDuration = if (item.durationMs > 0) item.durationMs else existing.totalDuration,
+                                watchedAt = item.watchedAtMillis(),
+                            )
+                        )
+                    }
+                }
+                // A full TV row from another box: rebuild it verbatim.
+                item.extra != null && session != null -> {
+                    item.toEntity(session)?.let { local.addHistory(it) }
+                }
+                // Phone-only row: nothing playable to build here. It stays on
+                // the server for the phone, and is not faked into this list.
+                else -> Unit
+            }
+        }
+    }
+
+    /** Room is keyed by session, so a cross-device match needs a scan. History is capped small. */
+    private suspend fun findByKey(key: String): WatchHistoryEntity? =
+        local.getAllHistory().firstOrNull { it.syncKey() == key }
+
+    // ─── tombstones ──────────────────────────────────────────────────────────
+
+    private fun readTombstones(): Map<String, String> {
+        val raw = prefs.getString(KEY_TOMBSTONES, null) ?: return emptyMap()
+        return runCatching { gson.fromJson<Map<String, String>>(raw, tombstoneType) }
+            .getOrNull() ?: emptyMap()
+    }
+
+    private fun writeTombstone(key: String) = writeTombstones(readTombstones() + (key to nowIso()))
+
+    private fun writeTombstones(all: Map<String, String>) {
+        prefs.edit().putString(KEY_TOMBSTONES, gson.toJson(all)).apply()
+    }
+
+    // ─── mapping ─────────────────────────────────────────────────────────────
+
+    private fun WatchHistoryEntity.toSyncItem() = HistorySyncItem(
+        provider = source.ifBlank { currentSourceName },
+        contentId = categoryid,
+        contentUrl = videoUrl,
+        title = mediaName.ifBlank { title },
+        thumbnail = image,
+        isSerial = isSeries,
+        episodeIndex = epIndex.takeIf { it >= 0 },
+        positionMs = lastPosition,
+        durationMs = totalDuration,
+        watchedAt = isoOf(watchedAt),
+        // The Room row rides along whole so another box can rebuild it exactly.
+        extra = mapOf(
+            EXTRA_SESSION to session,
+            "title" to title,
+            "mediaName" to mediaName,
+            "image" to image,
+            "categoryProperty" to categoryProperty,
+            "categoryid" to categoryid,
+            "country" to country,
+            "description" to description,
+            "language" to language,
+            "rating" to rating,
+            "page" to page,
+            "release_year" to release_year,
+            "videoUrl" to videoUrl,
+            "isEpisode" to isEpisode,
+            "imdbID" to imdbID,
+            "epIndex" to epIndex,
+            "currentQualityIndex" to currentQualityIndex,
+            "isAnime" to isAnime,
+            "isSeries" to isSeries,
+            "source" to source,
+            "currentSourceName" to currentSourceName,
+        ),
+    )
+
+    private fun HistorySyncItem.toEntity(session: String): WatchHistoryEntity? {
+        val e = extra ?: return null
+        fun str(k: String) = e[k] as? String
+        fun num(k: String) = (e[k] as? Number)
+        return WatchHistoryEntity(
+            session = session,
+            title = str("title") ?: title.orEmpty(),
+            mediaName = str("mediaName") ?: title.orEmpty(),
+            image = str("image") ?: thumbnail.orEmpty(),
+            categoryProperty = str("categoryProperty"),
+            categoryid = str("categoryid") ?: contentId,
+            country = str("country"),
+            description = str("description"),
+            language = str("language"),
+            rating = num("rating")?.toDouble(),
+            page = num("page")?.toInt(),
+            release_year = str("release_year"),
+            videoUrl = str("videoUrl") ?: contentUrl.orEmpty(),
+            totalDuration = durationMs,
+            lastPosition = positionMs,
+            watchedAt = watchedAtMillis(),
+            isEpisode = e["isEpisode"] as? Boolean ?: true,
+            imdbID = str("imdbID") ?: "-1",
+            epIndex = num("epIndex")?.toInt() ?: -1,
+            currentQualityIndex = num("currentQualityIndex")?.toInt() ?: -1,
+            isAnime = e["isAnime"] as? Boolean ?: true,
+            isSeries = e["isSeries"] as? Boolean ?: false,
+            source = str("source").orEmpty(),
+            currentSourceName = str("currentSourceName").orEmpty(),
+        )
+    }
+
+    private fun HistorySyncItem.watchedAtMillis(): Long =
+        parseIso(watchedAt).takeIf { it > 0 } ?: System.currentTimeMillis()
+
+    /**
+     * Mirrors the server's buildHistoryKey EXACTLY. Drifting from it splits one
+     * episode into two rows that never reconcile, so the two must change together.
+     */
+    private fun WatchHistoryEntity.syncKey(): String? {
+        val provider = source.ifBlank { currentSourceName }.trim()
+        val base = (categoryid?.takeIf { it.isNotBlank() } ?: videoUrl).trim()
+        if (base.isEmpty()) return null
+        val head = "$provider|$base"
+        if (!isSeries) return head
+        return if (epIndex < 0) head else "$head|e$epIndex"
+    }
+
+    private companion object {
+        const val FILE = "sozo_history_sync"
+        const val KEY_CURSOR = "cursor"
+        const val KEY_PUSHED_AT = "pushed_at"
+        const val KEY_TOMBSTONES = "tombstones"
+        const val EXTRA_SESSION = "session"
+
+        /** UTC, milliseconds - the format the server's `new Date(...)` parses without surprises. */
+        private fun formatter() = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+            .apply { timeZone = TimeZone.getTimeZone("UTC") }
+
+        fun nowIso(): String = formatter().format(Date())
+        fun isoOf(millis: Long): String = formatter().format(Date(millis))
+        fun parseIso(value: String?): Long =
+            value?.let { runCatching { formatter().parse(it)?.time }.getOrNull() } ?: 0L
+    }
+}

--- a/app/src/main/java/com/saikou/sozo_tv/di/koinModule.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/di/koinModule.kt
@@ -98,10 +98,10 @@ val koinModule = module {
     viewModel { WrongTitleViewModel() }
     viewModel { UpdateViewModel() }
     viewModel { ViewAllViewModel(get()) }
-    viewModel { SettingsViewModel(get(), profileRepo = get(), deviceAuth = get()) }
+    viewModel { SettingsViewModel(get(), profileRepo = get(), deviceAuth = get(), userLists = get(), historySync = get()) }
     viewModel { LiveTvViewModel(dao = get()) }
     viewModel { SplashViewModel(firebaseService = get()) }
-    viewModel { PlayAnimeViewModel(watchHistoryRepository = get()) }
+    viewModel { PlayAnimeViewModel(watchHistoryRepository = get(), historySync = get()) }
     viewModel { DetailViewModel(repo = get(), bookmarkRepo = get()) }
     viewModel { CategoriesViewModel(repo = get()) }
     viewModel { SearchViewModel(repo = get()) }

--- a/app/src/main/java/com/saikou/sozo_tv/di/networkModule.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/di/networkModule.kt
@@ -6,9 +6,11 @@ import com.saikou.sozo_tv.BuildConfig
 import com.saikou.sozo_tv.data.local.pref.DeviceSessionStore
 import com.saikou.sozo_tv.data.extensions.ExtensionEngine
 import com.saikou.sozo_tv.data.remote.device.DeviceAuthClient
+import com.saikou.sozo_tv.data.remote.history.WatchHistorySyncClient
 import com.saikou.sozo_tv.data.remote.lists.UserListsClient
 import com.saikou.sozo_tv.data.repository.DeviceAuthRepository
 import com.saikou.sozo_tv.data.repository.UserListsRepository
+import com.saikou.sozo_tv.data.repository.WatchHistorySyncRepository
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.android.ext.koin.androidContext
@@ -48,6 +50,25 @@ val NetworkModule = module {
         )
     }
     single { UserListsRepository(context = androidContext(), client = get()) }
+
+    // Watch history sync. Same auth transport and same per-request token as the
+    // lists above; the difference is that history is written by the player
+    // rather than by the user, so it pushes on its own schedule.
+    single {
+        WatchHistorySyncClient(
+            okHttpClient = get(named("authOkHttp")),
+            gson = get(),
+            baseUrl = BuildConfig.SOZO_API_BASE_URL,
+            tokenProvider = { get<DeviceAuthRepository>().accessToken() },
+        )
+    }
+    single {
+        WatchHistorySyncRepository(
+            context = androidContext(),
+            client = get(),
+            local = get(),
+        )
+    }
 
 }
 

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/activities/DeviceLoginActivity.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/activities/DeviceLoginActivity.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.saikou.sozo_tv.R
+import com.saikou.sozo_tv.data.repository.WatchHistorySyncRepository
 import com.saikou.sozo_tv.databinding.ActivityDeviceLoginBinding
 import com.saikou.sozo_tv.presentation.viewmodel.DeviceLoginState
 import com.saikou.sozo_tv.presentation.viewmodel.DeviceLoginViewModel
@@ -19,6 +20,7 @@ import com.saikou.sozo_tv.utils.gone
 import com.saikou.sozo_tv.utils.visible
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 /**
@@ -31,6 +33,7 @@ class DeviceLoginActivity : AppCompatActivity() {
     private val binding get() = _binding!!
 
     private val model: DeviceLoginViewModel by viewModel()
+    private val historySync: WatchHistorySyncRepository by inject()
     private val settingsViewModel: SettingsViewModel by viewModel()
 
     // Approved is a sticky StateFlow value, so re-collecting it after a STARTED restart would
@@ -130,6 +133,10 @@ class DeviceLoginActivity : AppCompatActivity() {
     /** Holds the linked account on screen briefly so an unexpected rebind is actually readable. */
     private fun handOffToProfile() {
         if (handedOff) return
+        // First pull for the account that just signed in. Without it this box
+        // shows nothing until the History screen happens to be opened, which is
+        // exactly the moment a new sign-in should already have caught up.
+        historySync.syncAsync()
         lifecycleScope.launch {
             delay(SIGNED_IN_DWELL_MS)
             // Latched only once the start actually happens: a hand-off that lands while the

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/history/HistoryPage.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/history/HistoryPage.kt
@@ -39,8 +39,29 @@ class HistoryPage : Fragment() {
     @SuppressLint("SetTextI18n")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        // Cached first, then synced. Rendering only after the network would
+        // leave the screen empty on a slow link for a list already on disk.
         lifecycleScope.launch {
-            val watchHistoryList = if (isAnimeEnabled) model.getAllWatchHistory()
+            renderHistory()
+            if (model.syncHistoryNow()) renderHistory()
+        }
+
+        binding.clearHistoryBtn.setOnClickListener {
+            val dialog = HistoryAlertDialog()
+            dialog.setNoClearListener {
+                dialog.dismiss()
+                clearHistory()
+            }
+            dialog.setYesContinueListener {
+                dialog.dismiss()
+            }
+            dialog.show(parentFragmentManager, "ConfirmationDialog")
+        }
+    }
+
+    @SuppressLint("SetTextI18n")
+    private suspend fun renderHistory() {
+        val watchHistoryList = if (isAnimeEnabled) model.getAllWatchHistory()
                 .filter { it.isAnime }
                 .filter {
                     it.source == PreferenceManager().getString(LocalData.SOURCE)
@@ -84,20 +105,8 @@ class HistoryPage : Fragment() {
                     }
                 }
 
-            } else {
-                showEmptyState()
-            }
-        }
-        binding.clearHistoryBtn.setOnClickListener {
-            val dialog = HistoryAlertDialog()
-            dialog.setNoClearListener {
-                dialog.dismiss()
-                clearHistory()
-            }
-            dialog.setYesContinueListener {
-                dialog.dismiss()
-            }
-            dialog.show(parentFragmentManager, "ConfirmationDialog")
+        } else {
+            showEmptyState()
         }
     }
 

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
@@ -1293,6 +1293,10 @@ class SeriesPlayerScreen : Fragment() {
 
     override fun onDestroyView() {
         stopProgressTracking()
+        // Push the position the viewer just stopped at, so a phone can pick it
+        // up. Without this the progress only leaves this box the next time the
+        // History screen happens to be opened.
+        model.syncHistory()
 
         thumbLoadJob?.cancel()
         thumbFetchJob?.cancel()

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/PlayAnimeViewModel.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/PlayAnimeViewModel.kt
@@ -9,6 +9,7 @@ import com.saikou.sozo_tv.aniskip.AniSkip
 import com.saikou.sozo_tv.data.local.entity.WatchHistoryEntity
 import com.saikou.sozo_tv.data.model.SubTitle
 import com.saikou.sozo_tv.data.model.VodMovieResponse
+import com.saikou.sozo_tv.data.repository.WatchHistorySyncRepository
 import com.saikou.sozo_tv.domain.repository.WatchHistoryRepository
 import com.saikou.sozo_tv.parser.models.EpisodeData
 import com.saikou.sozo_tv.parser.models.ShowResponse
@@ -21,6 +22,7 @@ import kotlinx.coroutines.launch
 
 class PlayAnimeViewModel(
     private val watchHistoryRepository: WatchHistoryRepository,
+    private val historySync: WatchHistorySyncRepository,
 ) : ViewModel() {
 
     companion object {
@@ -120,6 +122,9 @@ class PlayAnimeViewModel(
     }
 
     suspend fun removeHistory(videoUrl: String) {
+        // Tombstone first: once the Room row is gone there is nothing left to
+        // describe the delete, and the next sync would download it straight back.
+        watchHistoryRepository.getWatchHistoryById(videoUrl)?.let { historySync.rememberDeleted(it) }
         watchHistoryRepository.removeHistory(videoUrl)
     }
 
@@ -133,9 +138,29 @@ class PlayAnimeViewModel(
 
     fun clearAllHistory() {
         viewModelScope.launch(Dispatchers.IO) {
-            runCatching { watchHistoryRepository.clearAllHistory() }
+            runCatching {
+                historySync.rememberClearedAll()
+                watchHistoryRepository.clearAllHistory()
+                // Push immediately so the phone does not keep showing a list
+                // the user just emptied here.
+                historySync.sync()
+            }
         }
     }
+
+    /**
+     * Pull other devices' progress and push this box's.
+     *
+     * Fire-and-forget on purpose: history is a convenience, and a screen must
+     * never wait on the network to render the copy it already has.
+     */
+    fun syncHistory() {
+        viewModelScope.launch(Dispatchers.IO) { runCatching { historySync.sync() } }
+    }
+
+    /** Awaitable form, for a screen that wants to redraw once the pull lands. */
+    suspend fun syncHistoryNow(): Boolean =
+        runCatching { historySync.sync() }.getOrDefault(false)
 
     fun updateQualityByIndex() {
         if (videoOptions.isEmpty()) return

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/SettingsViewModel.kt
@@ -9,6 +9,8 @@ import com.saikou.sozo_tv.data.model.ContentMode
 import com.saikou.sozo_tv.data.model.SeasonalTheme
 import com.saikou.sozo_tv.data.model.anilist.Profile
 import com.saikou.sozo_tv.data.repository.DeviceAuthRepository
+import com.saikou.sozo_tv.data.repository.WatchHistorySyncRepository
+import com.saikou.sozo_tv.data.repository.UserListsRepository
 import com.saikou.sozo_tv.domain.repository.ProfileRepository
 import com.saikou.sozo_tv.domain.repository.SettingsRepository
 import com.saikou.sozo_tv.utils.LocalData
@@ -21,6 +23,8 @@ class SettingsViewModel(
     private val settingsRepository: SettingsRepository,
     private val profileRepo: ProfileRepository,
     private val deviceAuth: DeviceAuthRepository,
+    private val userLists: UserListsRepository,
+    private val historySync: WatchHistorySyncRepository,
 ) : ViewModel() {
 
     val contentMode: StateFlow<ContentMode> =
@@ -61,6 +65,13 @@ class SettingsViewModel(
 
     /** Revokes only THIS device's session — the user's phone and other TVs stay signed in. */
     fun exitUser() {
+        // Account-scoped caches go first, and synchronously. A TV is a shared
+        // screen: leaving the previous account's Watch Later and watch history
+        // on the box after a visible sign-out shows one person's viewing to the
+        // next. Both are plain local wipes, so there is nothing to await.
+        userLists.clear()
+        historySync.clear()
+
         // Runs on the repository's scope, not viewModelScope: the Exit dialog relaunches
         // MainActivity with CLEAR_TASK in the same handler, which tears this ViewModel down and
         // would abandon the revocation call mid-flight, leaving the session alive server-side.


### PR DESCRIPTION
Starting an episode on the phone and finishing it here meant finding your place again by hand. History was local to the box.

Depends on **sozo-backend#7**, which adds `POST /auth/history/sync`.

## What syncs — deliberately not "everything"

A row here is a Room record keyed by a provider `session`, a handle for one episode stream on this box, and its `contentUrl` is a stream address. A phone row cannot be turned into a playable one, so materialising it would fill History with entries that open nothing.

| Direction | What travels |
|---|---|
| TV → TV | whole rows, carried in `extra` so a second box rebuilds them intact |
| TV ↔ phone | the resume position, on content both can already name |

The Flutter client applies the mirror-image rule, so neither side invents a row it cannot open.

## New

- `WatchHistorySyncClient` — transport for `/auth/history/sync`, on the same `authOkHttp` client as device sign-in (platform TLS, no body logging; the app's content client trusts any certificate and must never carry a bearer token)
- `WatchHistorySyncRepository` — cursor, tombstones, and the Room merge

## Decisions worth reviewing

**Deletes are recorded before the Room row goes.** The DAO removes rows outright, so a delete leaves nothing to upload — and the next sync would see the server's copy as new and put the row straight back.

**The sync key mirrors the server's `buildHistoryKey` exactly.** Drifting from it does not fail loudly; it splits one episode into two rows that never reconcile. The two must change together.

**Syncs fire where progress changes** — leaving the player, opening History, clearing it, signing in. Without the player hook, progress only left the box when someone happened to open the History screen.

**Sign-out now wipes account-scoped caches.** The history cursor was the new one, but the curated lists cache had the same hole already — a TV is a shared screen, and leaving one person's Watch Later and viewing on it after a visible sign-out shows it to whoever sits down next.

## Known limitation

This box stores `epIndex`; the phone stores `episodeNumber`. Keys line up when the numbering agrees, which is reliable for backend-served content (both apps read the same API) but not guaranteed for extension sources.

## Testing

Builds clean. Not yet exercised against a live account with two real devices — that pass is still owed:

1. Watch half an episode on the phone, leave the player
2. Open History here — it should resume from the phone's position
3. Clear history here — the phone's list should empty too