### PR TITLE
AniList on TV, and fixes to parallel search, voice search and focus

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -274,4 +274,10 @@ dependencies {
     implementation("io.reactivex:rxjava:1.3.8")
     // JS engine for Aniyomi extractors that deobfuscate links (QuickJS).
     implementation("app.cash.quickjs:quickjs-android:0.9.2")
+
+    // Local JVM tests. Only for logic with no Android dependency — the title
+    // normalisation and episode arithmetic behind AniList tracking, where every
+    // failure mode is silent (a wrong match writes to the wrong list, and
+    // nothing errors).
+    testImplementation("junit:junit:4.13.2")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,15 +10,38 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
 
+    <!--
+      Package visibility (Android 11+). Without this the platform hides speech
+      recognisers from us entirely: SpeechRecognizer.isRecognitionAvailable()
+      returns false and Intent.resolveActivity() returns null even when Google's
+      recogniser is installed and working. Both voice-search paths then fall
+      through to "Voice search not available", which is why it was dead on every
+      modern box.
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.speech.RecognitionService" />
+        </intent>
+        <intent>
+            <action android:name="android.speech.action.RECOGNIZE_SPEECH" />
+        </intent>
+    </queries>
+
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />
     <uses-feature
         android:name="android.software.leanback"
         android:required="true" />
+    <!--
+      required="false": plenty of Android TV boxes have no built-in microphone
+      (the mic lives in the remote, or there is none at all). Marked required,
+      this line makes the app UNINSTALLABLE on those devices for the sake of one
+      optional button.
+    -->
     <uses-feature
         android:name="android.hardware.microphone"
-        android:required="true"
+        android:required="false"
         tools:ignore="UnsupportedTvHardware" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/app/src/main/java/com/saikou/sozo_tv/adapters/AnilistAdapters.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/adapters/AnilistAdapters.kt
@@ -1,0 +1,110 @@
+package com.saikou.sozo_tv.adapters
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.saikou.sozo_tv.data.remote.anilist.AnilistListEntry
+import com.saikou.sozo_tv.data.remote.anilist.AnilistStatus
+import com.saikou.sozo_tv.databinding.ItemAnilistEntryBinding
+import com.saikou.sozo_tv.databinding.ItemAnilistStatusBinding
+import com.saikou.sozo_tv.utils.applyTvFocusScale
+import com.saikou.sozo_tv.utils.loadImage
+
+/** One title in the AniList library grid. */
+class AnilistEntryAdapter(
+    private val onClick: (AnilistListEntry) -> Unit,
+) : ListAdapter<AnilistListEntry, AnilistEntryAdapter.VH>(DIFF) {
+
+    inner class VH(private val binding: ItemAnilistEntryBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        @SuppressLint("SetTextI18n")
+        fun bind(entry: AnilistListEntry) = with(binding) {
+            val media = entry.media
+            entryTitle.text = media.displayTitle
+            entryProgress.text = media.episodes
+                ?.let { "${entry.progress} / $it" }
+                ?: entry.progress.toString()
+
+            media.coverImage?.takeIf { it.isNotBlank() }?.let { coverImage.loadImage(it) }
+
+            progressBar.progress = ((entry.completion ?: 0f) * 100).toInt()
+
+            val behind = entry.behindBy
+            behindBadge.isVisible = behind > 0
+            if (behind > 0) behindBadge.text = "+$behind"
+
+            root.applyTvFocusScale(scale = 1.06f)
+            root.setOnClickListener { onClick(entry) }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = VH(
+        ItemAnilistEntryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+    )
+
+    override fun onBindViewHolder(holder: VH, position: Int) = holder.bind(getItem(position))
+
+    private companion object {
+        /**
+         * Compared by CONTENT, not just id: a "+1" writes a new progress value
+         * onto the same entry, and an identity-only diff would leave the old
+         * number on screen.
+         */
+        val DIFF = object : DiffUtil.ItemCallback<AnilistListEntry>() {
+            override fun areItemsTheSame(a: AnilistListEntry, b: AnilistListEntry) = a.id == b.id
+            override fun areContentsTheSame(a: AnilistListEntry, b: AnilistListEntry) =
+                a.progress == b.progress && a.status == b.status && a.media.id == b.media.id
+        }
+    }
+}
+
+/** The status filter row. */
+class AnilistStatusAdapter(
+    private val onPick: (AnilistStatus) -> Unit,
+) : RecyclerView.Adapter<AnilistStatusAdapter.VH>() {
+
+    private val statuses = AnilistStatus.entries
+    private var counts: Map<AnilistStatus, Int> = emptyMap()
+    private var selected: AnilistStatus = AnilistStatus.CURRENT
+
+    fun setCounts(counts: Map<AnilistStatus, Int>) {
+        this.counts = counts
+        notifyItemRangeChanged(0, statuses.size)
+    }
+
+    fun setSelected(status: AnilistStatus) {
+        if (selected == status) return
+        val previous = statuses.indexOf(selected)
+        selected = status
+        // Two targeted updates rather than notifyDataSetChanged: rebinding the
+        // whole row while the d-pad sits on one of these chips drops focus back
+        // to the screen root.
+        notifyItemChanged(previous)
+        notifyItemChanged(statuses.indexOf(status))
+    }
+
+    inner class VH(private val binding: ItemAnilistStatusBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(status: AnilistStatus) = with(binding.statusLabel) {
+            val count = counts[status] ?: 0
+            text = if (count > 0) "${status.label}  $count" else status.label
+            isSelected = status == selected
+            applyTvFocusScale(scale = 1.04f)
+            setOnClickListener { onPick(status) }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = VH(
+        ItemAnilistStatusBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+    )
+
+    override fun onBindViewHolder(holder: VH, position: Int) = holder.bind(statuses[position])
+
+    override fun getItemCount() = statuses.size
+}

--- a/app/src/main/java/com/saikou/sozo_tv/adapters/AnilistAdapters.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/adapters/AnilistAdapters.kt
@@ -22,6 +22,13 @@ class AnilistEntryAdapter(
     inner class VH(private val binding: ItemAnilistEntryBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
+        init {
+            // Once per holder, not per bind: applyTvFocusScale resets the scale
+            // and re-registers the focus listener, and doing that to a recycled
+            // view while it holds focus makes the highlight jump.
+            binding.root.applyTvFocusScale(scale = 1.06f)
+        }
+
         @SuppressLint("SetTextI18n")
         fun bind(entry: AnilistListEntry) = with(binding) {
             val media = entry.media
@@ -38,7 +45,6 @@ class AnilistEntryAdapter(
             behindBadge.isVisible = behind > 0
             if (behind > 0) behindBadge.text = "+$behind"
 
-            root.applyTvFocusScale(scale = 1.06f)
             root.setOnClickListener { onClick(entry) }
         }
     }
@@ -91,11 +97,14 @@ class AnilistStatusAdapter(
     inner class VH(private val binding: ItemAnilistStatusBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
+        init {
+            binding.statusLabel.applyTvFocusScale(scale = 1.04f)
+        }
+
         fun bind(status: AnilistStatus) = with(binding.statusLabel) {
             val count = counts[status] ?: 0
             text = if (count > 0) "${status.label}  $count" else status.label
             isSelected = status == selected
-            applyTvFocusScale(scale = 1.04f)
             setOnClickListener { onPick(status) }
         }
     }

--- a/app/src/main/java/com/saikou/sozo_tv/app/MyApp.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/app/MyApp.kt
@@ -17,6 +17,12 @@ import com.saikou.sozo_tv.di.firebaseModule
 import com.saikou.sozo_tv.di.koinModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
+import com.saikou.sozo_tv.data.repository.AnilistRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.get
 import org.koin.core.context.startKoin
 import java.lang.ref.WeakReference
 
@@ -42,7 +48,24 @@ class MyApp : Application() {
             androidLogger()
             modules(NetworkModule, koinModule, firebaseModule)
         }
+        warmAnilistLink()
 
+    }
+
+    /**
+     * Reads the account's AniList link once at startup.
+     *
+     * Not required for correctness — the tracker reads it lazily too — but it
+     * means the AniList screen and the first episode of a session already know
+     * the answer instead of waiting on a round trip.
+     *
+     * Failure is silent by design: no AniList, no account, or no network are all
+     * ordinary states, and none of them should say anything at app launch.
+     */
+    private fun warmAnilistLink() {
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            runCatching { get<AnilistRepository>().refresh() }
+        }
     }
 
     /**

--- a/app/src/main/java/com/saikou/sozo_tv/data/extensions/ExtModels.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/extensions/ExtModels.kt
@@ -100,6 +100,17 @@ data class ExtDetail(
     val cast: List<ExtCast>,
     val related: List<ExtCard>,
     val episodes: List<ExtEpisode>,
+    /**
+     * The AniList entry this page IS, when the provider says so.
+     *
+     * The difference between exact tracking and guessing. A provider that
+     * reports its AniList id removes title normalisation, season ambiguity and
+     * every chance of filing episodes into the wrong show. Null for the many
+     * sources that do not report one — those still go through title matching.
+     */
+    val anilistId: Int? = null,
+    /** Same, for MyAnimeList. Carried for a future tracker; unused today. */
+    val malId: Int? = null,
 )
 
 data class ExtVideoSource(
@@ -268,6 +279,9 @@ internal object ExtParser {
             genres = genres,
             type = o.strOrNull("type"),
             isSerial = o.optBoolean("isSerial", eps.size > 1),
+            anilistId = o.optJSONObject("syncIds")?.intOrNull("anilist"),
+            malId = o.optJSONObject("syncIds")?.intOrNull("mal")
+                ?: o.optJSONObject("syncIds")?.intOrNull("myanimelist"),
             cast = cast,
             related = cards(o.optJSONArray("related")),
             episodes = eps,

--- a/app/src/main/java/com/saikou/sozo_tv/data/extensions/ExtModels.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/extensions/ExtModels.kt
@@ -320,3 +320,21 @@ internal object ExtParser {
         )
     }
 }
+
+/** Outcome of one provider's leg in an "all sources" search. */
+enum class SearchLegStatus { OK, EMPTY, TIMEOUT, ERROR }
+
+/**
+ * One provider's answer.
+ *
+ * Carries the status rather than just the items so the UI can tell "this source
+ * is down" from "no match here" — they look identical as an empty list, and only
+ * one of them is worth retrying.
+ */
+data class SearchLeg(
+    val provider: ExtProvider,
+    val items: List<ExtCard>,
+    val status: SearchLegStatus,
+) {
+    val hasItems: Boolean get() = items.isNotEmpty()
+}

--- a/app/src/main/java/com/saikou/sozo_tv/data/extensions/ExtensionEngine.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/extensions/ExtensionEngine.kt
@@ -1,6 +1,7 @@
 package com.saikou.sozo_tv.data.extensions
 
 import android.content.Context
+import android.util.Log
 import com.saikou.sozo_tv.app.MyApp
 import com.saikou.sozo_tv.data.local.pref.PreferenceManager
 import com.saikou.sozo_tv.engine.aniyomi.AniyomiHost
@@ -18,6 +19,14 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
 class ExtensionEngine(private val appContext: Context = MyApp.context) {
 
@@ -228,29 +237,40 @@ class ExtensionEngine(private val appContext: Context = MyApp.context) {
     }
 
     /**
-     * "All sources": search every installed provider across all three groups
-     * instead of only the active one.
+     * "All sources", emitted INCREMENTALLY: one item per provider, the moment
+     * that provider answers.
      *
-     * Three bounds, all load-bearing — a CloudStream repo alone can install
-     * dozens of providers, and a naive fan-out would hang the screen on the
-     * slowest dead mirror:
-     *   - [maxProviders] caps how many are queried at all,
-     *   - [perProviderTimeoutMs] caps each one INDEPENDENTLY, so one stalled
-     *     source costs its own slot and nothing else,
-     *   - a throwing/empty source is dropped rather than failing the search.
+     * The previous version awaited every provider before returning anything, so
+     * a single dead mirror held the whole screen blank for the full timeout even
+     * when eight sources had already replied in under a second. On a TV, where
+     * there is no spinner worth watching and no way to peek at partial results,
+     * that reads as "search is broken".
      *
-     * The active provider is queried FIRST so its hits lead the merged list —
-     * that is the source the user already chose. Results are deduped on
-     * (provider, contentUrl): the same title legitimately appears on several
-     * sources and each is separately playable, so only exact repeats collapse.
+     * Four bounds, all load-bearing — a CloudStream repo alone can install
+     * dozens of providers:
+     *   - [maxProviders] caps how many are queried at all;
+     *   - [concurrency] caps how many run AT ONCE. The old fan-out launched all
+     *     twelve together, and each one may dex-load an extension APK; on a
+     *     low-end box that is a thundering herd that slows every leg down;
+     *   - [perProviderTimeoutMs] caps each leg independently, so one stalled
+     *     source costs its own slot and nothing else;
+     *   - cancelling the flow stops scheduling further work.
+     *
+     * The active provider is queried FIRST so its hits arrive first — that is
+     * the source the user already chose.
+     *
+     * Every leg reports a [SearchLegStatus] rather than being silently dropped.
+     * "This source is down" and "no match here" look identical to a user
+     * otherwise, and only one of them is worth retrying.
      */
-    suspend fun searchAll(
+    fun searchAllFlow(
         query: String,
         maxProviders: Int = MAX_GLOBAL_PROVIDERS,
+        concurrency: Int = GLOBAL_SEARCH_CONCURRENCY,
         perProviderTimeoutMs: Long = GLOBAL_SEARCH_TIMEOUT_MS,
-    ): List<ExtCard> = withContext(Dispatchers.IO) {
+    ): Flow<SearchLeg> = channelFlow {
         val q = query.trim()
-        if (q.isEmpty()) return@withContext emptyList()
+        if (q.isEmpty()) return@channelFlow
 
         val active = getActiveProvider()
         val candidates = listOf(ExtGroup.SERVER, ExtGroup.ANIYOMI, ExtGroup.CLOUDSTREAM)
@@ -259,16 +279,63 @@ class ExtensionEngine(private val appContext: Context = MyApp.context) {
             .sortedByDescending { it.id == active }
             .take(maxProviders)
 
-        val pages = candidates.map { p ->
-            async {
-                withTimeoutOrNull(perProviderTimeoutMs) {
-                    runCatching { search(p.id, q)?.items }.getOrNull().orEmpty()
-                }.orEmpty()
-            }
-        }.map { it.await() }
+        if (candidates.isEmpty()) return@channelFlow
 
+        // A plain index shared by the workers: each takes the next provider when
+        // it frees up, which keeps exactly `concurrency` searches in flight
+        // rather than starting them all and hoping.
+        val next = AtomicInteger(0)
+        val workers = minOf(concurrency, candidates.size).coerceAtLeast(1)
+
+        coroutineScope {
+            repeat(workers) {
+                launch(Dispatchers.IO) {
+                    while (isActive) {
+                        val i = next.getAndIncrement()
+                        if (i >= candidates.size) return@launch
+                        send(searchOne(candidates[i], q, perProviderTimeoutMs))
+                    }
+                }
+            }
+        }
+    }
+
+    /** One provider's leg. Never throws — the outcome is carried in the result. */
+    private suspend fun searchOne(
+        provider: ExtProvider,
+        query: String,
+        timeoutMs: Long,
+    ): SearchLeg = try {
+        val items = withTimeoutOrNull(timeoutMs) {
+            search(provider.id, query)?.items.orEmpty()
+        }
+        when {
+            items == null -> SearchLeg(provider, emptyList(), SearchLegStatus.TIMEOUT)
+            items.isEmpty() -> SearchLeg(provider, emptyList(), SearchLegStatus.EMPTY)
+            else -> SearchLeg(provider, items, SearchLegStatus.OK)
+        }
+    } catch (c: CancellationException) {
+        throw c
+    } catch (t: Throwable) {
+        Log.w("ExtensionEngine", "search failed on ${provider.id}: ${t.message}")
+        SearchLeg(provider, emptyList(), SearchLegStatus.ERROR)
+    }
+
+    /**
+     * Blocking "all sources" search, kept for callers that genuinely need the
+     * whole set at once. Built on [searchAllFlow] so there is one fan-out
+     * implementation rather than two that drift apart.
+     */
+    suspend fun searchAll(
+        query: String,
+        maxProviders: Int = MAX_GLOBAL_PROVIDERS,
+        perProviderTimeoutMs: Long = GLOBAL_SEARCH_TIMEOUT_MS,
+    ): List<ExtCard> {
         val seen = HashSet<String>()
-        pages.flatten().filter { seen.add("${it.provider}|${it.contentUrl}") }
+        return searchAllFlow(query, maxProviders, perProviderTimeoutMs = perProviderTimeoutMs)
+            .toList()
+            .flatMap { it.items }
+            .filter { seen.add("${it.provider}|${it.contentUrl}") }
     }
 
     suspend fun load(provider: String, url: String): ExtDetail? = withContext(Dispatchers.IO) {
@@ -296,9 +363,31 @@ class ExtensionEngine(private val appContext: Context = MyApp.context) {
         private const val KEY_PROVIDER_NAME = "active_provider_name"
         private const val HOME_TIMEOUT_MS = 25_000L
 
-        /** Global-search bounds — see [searchAll]. */
+        /** Global-search bounds — see [searchAllFlow]. */
         private const val MAX_GLOBAL_PROVIDERS = 12
-        private const val GLOBAL_SEARCH_TIMEOUT_MS = 12_000L
+
+        /**
+         * How many provider searches run at once.
+         *
+         * Four, not twelve: each leg may download and dex-load an extension APK
+         * before it can issue a single request, and a TV box has a fraction of a
+         * phone's CPU. Running them all together made every leg slower and made
+         * the first result arrive later, which is the opposite of the point.
+         */
+        private const val GLOBAL_SEARCH_CONCURRENCY = 4
+
+        /**
+         * Per-provider budget.
+         *
+         * Raised from 12s because the first search against a freshly-installed
+         * source has to fetch and dex-load its extension before it can do
+         * anything — several megabytes over whatever connection the box has.
+         * Under the old ceiling every extension timed out on first use, which is
+         * exactly when the user had just added sources and was watching.
+         * Later searches hit the cached extension and return in well under a
+         * second, so this is only ever paid once per source.
+         */
+        private const val GLOBAL_SEARCH_TIMEOUT_MS = 40_000L
 
         val shared: ExtensionEngine by lazy { ExtensionEngine() }
     }

--- a/app/src/main/java/com/saikou/sozo_tv/data/local/database/AppDatabase.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/local/database/AppDatabase.kt
@@ -2,6 +2,8 @@ package com.saikou.sozo_tv.data.local.database
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.saikou.sozo_tv.data.local.dao.ChannelDao
 import com.saikou.sozo_tv.data.local.dao.CharacterDao
 import com.saikou.sozo_tv.data.local.dao.MovieDao
@@ -13,7 +15,7 @@ import com.saikou.sozo_tv.data.local.entity.WatchHistoryEntity
 
 @Database(
     entities = [AnimeBookmark::class, CharacterEntity::class, WatchHistoryEntity::class, ChannelsEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -21,4 +23,21 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun tvDao(): ChannelDao
     abstract fun characterDao(): CharacterDao
     abstract fun watchHistoryDao(): WatchHistoryDao
+}
+
+/**
+ * Adds `providerId` to watch history.
+ *
+ * A real migration rather than a destructive fallback: this database also holds
+ * every bookmark and every character the user saved, and losing those to add one
+ * nullable-ish column would be a far worse bug than the one being fixed.
+ *
+ * Existing rows get "" and keep syncing under their old identity — they were
+ * written before the app knew which provider played them, and inventing one now
+ * would be a guess.
+ */
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE watch_history ADD COLUMN providerId TEXT NOT NULL DEFAULT ''")
+    }
 }

--- a/app/src/main/java/com/saikou/sozo_tv/data/local/entity/AnimeBookmark.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/local/entity/AnimeBookmark.kt
@@ -70,6 +70,21 @@ data class WatchHistoryEntity(
     val currentQualityIndex: Int = -1,
     val isAnime: Boolean = true,
     val isSeries: Boolean = false,
+    /**
+     * Routing sentinel (`AnimeSources.EXTENSION`), NOT a provider identity.
+     * The History screen filters on it and the player routes on it, so it must
+     * keep meaning "an extension played this".
+     */
     var source: String = "",
-    val currentSourceName: String = ""
+    val currentSourceName: String = "",
+    /**
+     * The real active provider, prefixed exactly as the mobile app prefixes it
+     * (`cs:` CloudStream, `an:` Aniyomi).
+     *
+     * Separate from [source] because that field is a routing sentinel with the
+     * same value for every extension — which meant every row from every source
+     * shared one sync identity, and no TV row could ever line up with the
+     * phone's. Empty on rows written before this column existed.
+     */
+    val providerId: String = ""
 )

--- a/app/src/main/java/com/saikou/sozo_tv/data/remote/anilist/AnilistGraphQlClient.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/remote/anilist/AnilistGraphQlClient.kt
@@ -1,0 +1,284 @@
+package com.saikou.sozo_tv.data.remote.anilist
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Talks to AniList's GraphQL API directly.
+ *
+ * Hand-rolled JSON rather than Gson models: AniList nests every field two or
+ * three levels deep behind optional containers, and a tree of nullable DTOs to
+ * mirror that costs more to read than the twenty lines of parsing below.
+ *
+ * Uses the auth OkHttp client (platform TLS) — the app's content client trusts
+ * any certificate, which must never carry someone's AniList token.
+ */
+class AnilistGraphQlClient(
+    private val okHttpClient: OkHttpClient,
+) {
+
+    /**
+     * Runs [query] and returns its `data` object.
+     *
+     * @throws AnilistException on a transport failure OR on a GraphQL error,
+     *   which AniList reports inside a 200 body — a non-throwing HTTP call is
+     *   not the same as a successful query.
+     */
+    private suspend fun run(
+        query: String,
+        variables: JSONObject = JSONObject(),
+        token: String? = null,
+    ): JSONObject = withContext(Dispatchers.IO) {
+        val payload = JSONObject()
+            .put("query", query)
+            .put("variables", variables)
+            .toString()
+            .toRequestBody(JSON)
+
+        val request = Request.Builder()
+            .url(ENDPOINT)
+            .addHeader("Accept", "application/json")
+            .addHeader("Content-Type", "application/json")
+            .apply { token?.let { addHeader("Authorization", "Bearer $it") } }
+            .post(payload)
+            .build()
+
+        val raw = try {
+            okHttpClient.newCall(request).execute().use { it.body.string() }
+        } catch (t: Throwable) {
+            throw AnilistException("AniList bilan bog'lanib bo'lmadi", t)
+        }
+
+        val body = runCatching { JSONObject(raw) }.getOrNull()
+            ?: throw AnilistException("AniList javobini o'qib bo'lmadi")
+
+        body.optJSONArray("errors")?.takeIf { it.length() > 0 }?.let { errors ->
+            val message = errors.optJSONObject(0)?.optString("message").orEmpty()
+            throw AnilistException(message.ifBlank { "AniList so'rovni rad etdi" })
+        }
+
+        body.optJSONObject("data") ?: throw AnilistException("AniList ma'lumot qaytarmadi")
+    }
+
+    /** Who the stored token belongs to. Also the cheapest check that it still works. */
+    suspend fun viewer(token: String): AnilistViewer {
+        val data = run("query { Viewer { id name avatar { large } } }", token = token)
+        val v = data.optJSONObject("Viewer")
+            ?: throw AnilistException("AniList hisobi topilmadi")
+        return AnilistViewer(
+            id = v.optInt("id"),
+            name = v.optString("name"),
+            avatarUrl = v.optJSONObject("avatar")?.optStringOrNull("large"),
+        )
+    }
+
+    /**
+     * The viewer's anime list, every status in one call.
+     *
+     * Flattened here so the grouping decision stays in the UI rather than being
+     * baked into the transport — and de-duped by entry id, because a title on a
+     * custom list is repeated under several list objects.
+     */
+    suspend fun mediaList(token: String, userId: Int): List<AnilistListEntry> {
+        val query = """
+            query (${'$'}userId: Int) {
+              MediaListCollection(userId: ${'$'}userId, type: ANIME) {
+                lists {
+                  entries {
+                    id
+                    status
+                    progress
+                    score(format: POINT_10)
+                    updatedAt
+                    media { $MEDIA_FIELDS }
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val data = run(query, JSONObject().put("userId", userId), token)
+        val lists = data.optJSONObject("MediaListCollection")?.optJSONArray("lists")
+            ?: return emptyList()
+
+        val seen = HashSet<Int>()
+        val out = ArrayList<AnilistListEntry>()
+        for (i in 0 until lists.length()) {
+            val entries = lists.optJSONObject(i)?.optJSONArray("entries") ?: continue
+            for (j in 0 until entries.length()) {
+                val entry = entries.optJSONObject(j)?.toListEntry() ?: continue
+                if (seen.add(entry.id)) out.add(entry)
+            }
+        }
+        return out
+    }
+
+    /**
+     * The viewer's own entry for one title, or null when it is not on their list.
+     *
+     * Read before every automatic write so progress is never moved BACKWARDS: a
+     * rewatch, a second device, or a partly-watched episode would otherwise
+     * overwrite a higher number the account already holds.
+     */
+    suspend fun entryState(token: String, mediaId: Int): AnilistEntryState? {
+        val query = """
+            query (${'$'}mediaId: Int) {
+              Media(id: ${'$'}mediaId, type: ANIME) {
+                episodes
+                mediaListEntry { progress status }
+              }
+            }
+        """.trimIndent()
+
+        val media = run(query, JSONObject().put("mediaId", mediaId), token)
+            .optJSONObject("Media") ?: return null
+        val entry = media.optJSONObject("mediaListEntry")
+        return AnilistEntryState(
+            onList = entry != null,
+            progress = entry?.optInt("progress", 0) ?: 0,
+            status = entry?.optStringOrNull("status"),
+            totalEpisodes = media.optIntOrNull("episodes"),
+        )
+    }
+
+    /** Public title search — used to attach an AniList id to a locally-watched title. */
+    suspend fun searchMedia(search: String, perPage: Int = 20): List<AnilistMedia> {
+        if (search.isBlank()) return emptyList()
+        val query = """
+            query (${'$'}search: String, ${'$'}perPage: Int) {
+              Page(page: 1, perPage: ${'$'}perPage) {
+                media(search: ${'$'}search, type: ANIME, sort: SEARCH_MATCH) { $MEDIA_FIELDS }
+              }
+            }
+        """.trimIndent()
+
+        val variables = JSONObject().put("search", search.trim()).put("perPage", perPage)
+        val media = run(query, variables).optJSONObject("Page")?.optJSONArray("media")
+            ?: return emptyList()
+        return media.mapObjects { it.toMedia() }
+    }
+
+    /**
+     * Writes progress back to AniList.
+     *
+     * [progress] is an episode COUNT, not an index — AniList means "episodes
+     * finished", so passing a zero-based index silently reports one episode less
+     * than the viewer actually watched.
+     *
+     * Returns what AniList stored, which is not always what was sent: it clamps
+     * progress to the episode total and flips status to COMPLETED on the last one.
+     */
+    suspend fun saveProgress(
+        token: String,
+        mediaId: Int,
+        progress: Int,
+        status: String? = null,
+    ): AnilistSaveResult {
+        val mutation = """
+            mutation (${'$'}mediaId: Int, ${'$'}progress: Int, ${'$'}status: MediaListStatus) {
+              SaveMediaListEntry(mediaId: ${'$'}mediaId, progress: ${'$'}progress, status: ${'$'}status) {
+                id
+                progress
+                status
+              }
+            }
+        """.trimIndent()
+
+        val variables = JSONObject()
+            .put("mediaId", mediaId)
+            .put("progress", progress)
+        status?.let { variables.put("status", it) }
+
+        val saved = run(mutation, variables, token).optJSONObject("SaveMediaListEntry")
+            ?: throw AnilistException("AniList saqlamadi")
+        return AnilistSaveResult(
+            progress = saved.optInt("progress", progress),
+            status = saved.optStringOrNull("status") ?: status ?: AnilistStatus.CURRENT.value,
+        )
+    }
+
+    // ─── parsing ─────────────────────────────────────────────────────────────
+
+    private fun JSONObject.toListEntry(): AnilistListEntry? {
+        val media = optJSONObject("media")?.toMedia() ?: return null
+        return AnilistListEntry(
+            id = optInt("id"),
+            media = media,
+            status = optStringOrNull("status") ?: AnilistStatus.CURRENT.value,
+            progress = optInt("progress", 0),
+            score = optDoubleOrNull("score"),
+            updatedAt = optLong("updatedAt", 0L),
+        )
+    }
+
+    private fun JSONObject.toMedia(): AnilistMedia {
+        val title = optJSONObject("title")
+        val airing = optJSONObject("nextAiringEpisode")?.let {
+            val at = it.optLong("airingAt", 0L)
+            if (at > 0) AnilistAiring(episode = it.optInt("episode", 0), airingAt = at) else null
+        }
+        return AnilistMedia(
+            id = optInt("id"),
+            romajiTitle = title?.optStringOrNull("romaji"),
+            englishTitle = title?.optStringOrNull("english"),
+            nativeTitle = title?.optStringOrNull("native"),
+            coverImage = optJSONObject("coverImage")?.optStringOrNull("large"),
+            bannerImage = optStringOrNull("bannerImage"),
+            episodes = optIntOrNull("episodes"),
+            averageScore = optIntOrNull("averageScore"),
+            seasonYear = optIntOrNull("seasonYear"),
+            format = optStringOrNull("format"),
+            nextAiring = airing,
+        )
+    }
+
+    /** `optString` returns "null" for a JSON null, which is a real trap here. */
+    private fun JSONObject.optStringOrNull(key: String): String? =
+        if (isNull(key)) null else optString(key).takeIf { it.isNotBlank() }
+
+    private fun JSONObject.optIntOrNull(key: String): Int? =
+        if (!has(key) || isNull(key)) null else optInt(key)
+
+    private fun JSONObject.optDoubleOrNull(key: String): Double? =
+        if (isNull(key)) null else optDouble(key).takeIf { !it.isNaN() }
+
+    private inline fun <T> JSONArray.mapObjects(transform: (JSONObject) -> T): List<T> {
+        val out = ArrayList<T>(length())
+        for (i in 0 until length()) {
+            optJSONObject(i)?.let { out.add(transform(it)) }
+        }
+        return out
+    }
+
+    private companion object {
+        const val ENDPOINT = "https://graphql.anilist.co"
+        val JSON = "application/json; charset=utf-8".toMediaType()
+
+        /**
+         * The media selection every query shares. One constant rather than a copy
+         * per query: the parser reads these fields unconditionally, so a field
+         * added to search but forgotten in the library query would show up as a
+         * silently missing value rather than an error.
+         */
+        const val MEDIA_FIELDS = """
+            id
+            episodes
+            averageScore
+            seasonYear
+            format
+            title { romaji english native }
+            coverImage { large }
+            bannerImage
+            nextAiringEpisode { episode airingAt }
+        """
+    }
+}
+
+/** A failure that is AniList's fault, not the transport's — carried to the UI as text. */
+class AnilistException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/app/src/main/java/com/saikou/sozo_tv/data/remote/anilist/AnilistLinkClient.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/remote/anilist/AnilistLinkClient.kt
@@ -1,0 +1,105 @@
+package com.saikou.sozo_tv.data.remote.anilist
+
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import com.saikou.sozo_tv.data.remote.device.ApiResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Reads the AniList connection stored on the Sozo account.
+ *
+ * The TV never performs the OAuth handshake itself, and that is the whole point
+ * of putting the exchange on the server: an OAuth flow on a television means
+ * typing an AniList password with a d-pad. The phone connects once, the token is
+ * stored against the account, and this box simply picks it up.
+ *
+ * Shares the `authOkHttp` client with device sign-in for the same reason the
+ * history and lists clients do: this call carries a bearer token, and the app's
+ * content client trusts any certificate.
+ */
+class AnilistLinkClient(
+    private val okHttpClient: OkHttpClient,
+    private val gson: Gson,
+    private val baseUrl: String,
+    private val tokenProvider: suspend () -> String?,
+) {
+
+    /**
+     * The stored link, or `Ok(null)` when the account has none.
+     *
+     * "No link" is a successful answer, not an error — the caller shows an
+     * instruction rather than a failure.
+     */
+    suspend fun get(): ApiResult<AnilistLink?> = call("GET")
+
+    /** Removes the link from the account, and therefore from every device. */
+    suspend fun unlink(): ApiResult<AnilistLink?> = call("DELETE")
+
+    private suspend fun call(method: String): ApiResult<AnilistLink?> =
+        withContext(Dispatchers.IO) {
+            // No token => signed out. Reported as 401 so callers branch on the
+            // code rather than on message text.
+            val token = runCatching { tokenProvider() }.getOrNull()
+                ?: return@withContext ApiResult.Http(401, "Not signed in", null)
+
+            try {
+                val builder = Request.Builder()
+                    .url("${baseUrl.trimEnd('/')}$PATH")
+                    .addHeader("Authorization", "Bearer $token")
+                    .addHeader("Accept", "application/json")
+                when (method) {
+                    "DELETE" -> builder.delete()
+                    else -> builder.get()
+                }
+
+                okHttpClient.newCall(builder.build()).execute().use { resp ->
+                    val raw = resp.body.string()
+                    if (!resp.isSuccessful) {
+                        val msg = runCatching {
+                            gson.fromJson(raw, ApiMessage::class.java)?.message
+                        }.getOrNull()
+                        return@use ApiResult.Http(
+                            resp.code, msg, resp.header("Retry-After")?.trim()?.toIntOrNull(),
+                        )
+                    }
+                    val parsed = runCatching { gson.fromJson(raw, LinkResponse::class.java) }
+                        .getOrNull()
+                    ApiResult.Ok(parsed?.anilist?.takeIf { !it.accessToken.isNullOrBlank() })
+                }
+            } catch (t: Throwable) {
+                ApiResult.Network(t)
+            }
+        }
+
+    private data class LinkResponse(val anilist: AnilistLink? = null)
+
+    private data class ApiMessage(@SerializedName("message") val message: String?)
+
+    private companion object {
+        const val PATH = "/anilist/link"
+    }
+}
+
+/**
+ * The AniList connection as the account holds it.
+ *
+ * The access token travels to the client on purpose: this box talks to AniList
+ * directly, which keeps that traffic off the Sozo server and means an AniList
+ * outage degrades one feature instead of the whole app.
+ */
+data class AnilistLink(
+    val userId: Int? = null,
+    val name: String? = null,
+    val avatarUrl: String? = null,
+    val accessToken: String? = null,
+    val expiresAt: String? = null,
+    val linkedAt: String? = null,
+) {
+    fun viewer(): AnilistViewer? {
+        val id = userId ?: return null
+        return AnilistViewer(id = id, name = name.orEmpty(), avatarUrl = avatarUrl)
+    }
+}

--- a/app/src/main/java/com/saikou/sozo_tv/data/remote/anilist/AnilistLinkClient.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/remote/anilist/AnilistLinkClient.kt
@@ -5,8 +5,11 @@ import com.google.gson.annotations.SerializedName
 import com.saikou.sozo_tv.data.remote.device.ApiResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import com.saikou.sozo_tv.data.repository.RemoteTitleLink
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 
 /**
  * Reads the AniList connection stored on the Sozo account.
@@ -37,6 +40,45 @@ class AnilistLinkClient(
 
     /** Removes the link from the account, and therefore from every device. */
     suspend fun unlink(): ApiResult<AnilistLink?> = call("DELETE")
+
+    /**
+     * Exchanges this box's title->media map with the account.
+     *
+     * The reason the TV can track anything at all: a d-pad cannot realistically
+     * search AniList, and a translated source title will never match one exactly
+     * — so this box depends on associations the phone made by hand.
+     */
+    suspend fun syncLinks(items: List<Map<String, Any?>>): ApiResult<List<RemoteTitleLink>> =
+        withContext(Dispatchers.IO) {
+            val token = runCatching { tokenProvider() }.getOrNull()
+                ?: return@withContext ApiResult.Http(401, "Not signed in", null)
+
+            try {
+                val payload = gson.toJson(mapOf("items" to items)).toRequestBody(JSON)
+                val request = Request.Builder()
+                    .url("${baseUrl.trimEnd('/')}$PATH/sync")
+                    .addHeader("Authorization", "Bearer $token")
+                    .addHeader("Accept", "application/json")
+                    .addHeader("Content-Type", "application/json")
+                    .post(payload)
+                    .build()
+
+                okHttpClient.newCall(request).execute().use { resp ->
+                    val raw = resp.body.string()
+                    if (!resp.isSuccessful) {
+                        val msg = runCatching {
+                            gson.fromJson(raw, ApiMessage::class.java)?.message
+                        }.getOrNull()
+                        return@use ApiResult.Http(resp.code, msg, null)
+                    }
+                    val parsed = runCatching { gson.fromJson(raw, LinksResponse::class.java) }
+                        .getOrNull()
+                    ApiResult.Ok(parsed?.items.orEmpty())
+                }
+            } catch (t: Throwable) {
+                ApiResult.Network(t)
+            }
+        }
 
     private suspend fun call(method: String): ApiResult<AnilistLink?> =
         withContext(Dispatchers.IO) {
@@ -76,10 +118,13 @@ class AnilistLinkClient(
 
     private data class LinkResponse(val anilist: AnilistLink? = null)
 
+    private data class LinksResponse(val items: List<RemoteTitleLink>? = null)
+
     private data class ApiMessage(@SerializedName("message") val message: String?)
 
     private companion object {
         const val PATH = "/anilist/link"
+        val JSON = "application/json; charset=utf-8".toMediaType()
     }
 }
 

--- a/app/src/main/java/com/saikou/sozo_tv/data/remote/anilist/AnilistModels.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/remote/anilist/AnilistModels.kt
@@ -1,0 +1,134 @@
+package com.saikou.sozo_tv.data.remote.anilist
+
+/**
+ * The AniList shapes this app reads.
+ *
+ * Kept deliberately small: the TV shows a library and writes progress, so a
+ * faithful mirror of AniList's schema would be mostly dead fields that still
+ * have to be parsed on a box with a slow CPU.
+ */
+
+/** The account a stored token belongs to. */
+data class AnilistViewer(
+    val id: Int,
+    val name: String,
+    val avatarUrl: String? = null,
+)
+
+/** The next episode AniList expects to air. [airingAt] is a UNIX SECOND. */
+data class AnilistAiring(
+    val episode: Int,
+    val airingAt: Long,
+) {
+    val airsAtMillis: Long get() = airingAt * 1000L
+
+    /** Recomputed from the clock on every read, so a screen left open stays honest. */
+    val millisLeft: Long get() = airsAtMillis - System.currentTimeMillis()
+
+    val hasAired: Boolean get() = millisLeft <= 0
+}
+
+/** One anime. */
+data class AnilistMedia(
+    val id: Int,
+    val romajiTitle: String? = null,
+    val englishTitle: String? = null,
+    val nativeTitle: String? = null,
+    val coverImage: String? = null,
+    val bannerImage: String? = null,
+    val episodes: Int? = null,
+    val averageScore: Int? = null,
+    val seasonYear: Int? = null,
+    val format: String? = null,
+    val nextAiring: AnilistAiring? = null,
+) {
+    /**
+     * English first: source sites are indexed under the title people actually
+     * type, and a romaji-only name misses far more than it finds.
+     */
+    val displayTitle: String
+        get() = englishTitle?.takeIf { it.isNotBlank() }
+            ?: romajiTitle?.takeIf { it.isNotBlank() }
+            ?: nativeTitle.orEmpty()
+
+    /** Every title worth trying against a source, best guess first, no blanks or duplicates. */
+    val searchTitles: List<String>
+        get() = listOfNotNull(englishTitle, romajiTitle, nativeTitle)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+
+    /**
+     * Episodes that exist to watch right now.
+     *
+     * AniList keeps [episodes] at the announced season total while only
+     * `nextAiring.episode - 1` have actually gone out. Offering to mark an
+     * unaired episode watched is nonsense, so callers cap against this.
+     */
+    val airedEpisodes: Int?
+        get() = nextAiring?.takeIf { it.episode > 0 }?.let { it.episode - 1 } ?: episodes
+}
+
+/** One row of the viewer's library. */
+data class AnilistListEntry(
+    val id: Int,
+    val media: AnilistMedia,
+    val status: String,
+    /** Episodes FINISHED, not an index. */
+    val progress: Int,
+    val score: Double? = null,
+    val updatedAt: Long = 0,
+) {
+    /** The next episode to watch, capped at what has aired. Null when caught up. */
+    val nextEpisode: Int?
+        get() {
+            val aired = media.airedEpisodes
+            if (aired != null && progress >= aired) return null
+            return progress + 1
+        }
+
+    /** Aired but unwatched. 0 when caught up or unknown. */
+    val behindBy: Int
+        get() = media.airedEpisodes?.let { (it - progress).coerceAtLeast(0) } ?: 0
+
+    /** 0..1, or null for an ongoing show with no announced total, where a bar would be a guess. */
+    val completion: Float?
+        get() {
+            val total = media.episodes ?: return null
+            if (total <= 0) return null
+            return (progress.toFloat() / total).coerceIn(0f, 1f)
+        }
+}
+
+/** The viewer's position on one title, as AniList holds it. */
+data class AnilistEntryState(
+    val onList: Boolean,
+    val progress: Int,
+    val status: String?,
+    val totalEpisodes: Int?,
+)
+
+/** What AniList actually stored after a write. */
+data class AnilistSaveResult(
+    val progress: Int,
+    val status: String,
+)
+
+/**
+ * The statuses AniList exposes, in the order a library reads best.
+ *
+ * [label] is plain English here rather than a string resource because this app
+ * ships one language; the enum is the place to change that if it ever ships more.
+ */
+enum class AnilistStatus(val value: String, val label: String) {
+    CURRENT("CURRENT", "Watching"),
+    REPEATING("REPEATING", "Rewatching"),
+    PLANNING("PLANNING", "Planning"),
+    COMPLETED("COMPLETED", "Completed"),
+    PAUSED("PAUSED", "Paused"),
+    DROPPED("DROPPED", "Dropped");
+
+    companion object {
+        fun fromValue(value: String?): AnilistStatus? = entries.firstOrNull { it.value == value }
+    }
+}

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistLinkStore.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistLinkStore.kt
@@ -3,6 +3,10 @@ package com.saikou.sozo_tv.data.repository
 import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 /**
  * Remembers which AniList title a locally-watched title corresponds to.
@@ -20,6 +24,7 @@ class AnilistLinkStore(context: Context, private val gson: Gson = Gson()) {
 
     private val prefs = context.getSharedPreferences(FILE, Context.MODE_PRIVATE)
     private val mapType = object : TypeToken<Map<String, AnilistTitleLink>>() {}.type
+    private val tombstoneType = object : TypeToken<Map<String, Long>>() {}.type
 
     private fun read(): Map<String, AnilistTitleLink> {
         val raw = prefs.getString(KEY_LINKS, null) ?: return emptyMap()
@@ -33,6 +38,75 @@ class AnilistLinkStore(context: Context, private val gson: Gson = Gson()) {
         prefs.edit().putString(KEY_LINKS, gson.toJson(all)).apply()
     }
 
+    /**
+     * Keys unlinked here but not yet accepted by the account.
+     *
+     * Removing a row locally leaves nothing to upload, so without recording the
+     * removal the next sync would see the account's copy as new and put the link
+     * straight back.
+     */
+    private fun readTombstones(): Map<String, Long> {
+        val raw = prefs.getString(KEY_TOMBSTONES, null) ?: return emptyMap()
+        return runCatching { gson.fromJson<Map<String, Long>>(raw, tombstoneType) }
+            .getOrNull() ?: emptyMap()
+    }
+
+    private fun writeTombstones(all: Map<String, Long>) {
+        prefs.edit().putString(KEY_TOMBSTONES, gson.toJson(all)).apply()
+    }
+
+    /** Everything this box has to tell the account: its links, and its unlinks. */
+    fun pendingChanges(): List<Map<String, Any?>> = buildList {
+        read().forEach { (key, link) ->
+            add(
+                mapOf(
+                    "key" to key,
+                    "provider" to link.provider,
+                    "contentId" to link.contentId,
+                    "mediaId" to link.mediaId,
+                    "title" to link.title,
+                    "coverImage" to link.coverImage,
+                    "totalEpisodes" to link.totalEpisodes,
+                    "auto" to link.auto,
+                    "updatedAt" to isoOf(link.linkedAt),
+                )
+            )
+        }
+        readTombstones().forEach { (key, at) ->
+            add(mapOf("key" to key, "deletedAt" to isoOf(at), "updatedAt" to isoOf(at)))
+        }
+    }
+
+    /**
+     * Replaces the local map with the account's merged answer.
+     *
+     * Tombstones are dropped only here — they must survive until a sync has
+     * actually accepted them, or an unlink made offline would be forgotten.
+     */
+    fun applyRemote(items: List<RemoteTitleLink>) {
+        val map = LinkedHashMap<String, AnilistTitleLink>()
+        for (item in items) {
+            val key = item.key?.trim()?.lowercase().orEmpty()
+            if (key.isEmpty()) continue
+            // A tombstone is an instruction to forget, not a row to store.
+            if (item.deletedAt != null) continue
+            val mediaId = item.mediaId ?: continue
+            if (mediaId <= 0) continue
+            map[key] = AnilistTitleLink(
+                provider = item.provider.orEmpty(),
+                contentId = item.contentId.orEmpty(),
+                mediaId = mediaId,
+                title = item.title.orEmpty(),
+                coverImage = item.coverImage,
+                totalEpisodes = item.totalEpisodes,
+                linkedAt = parseIso(item.updatedAt),
+                auto = item.auto ?: false,
+            )
+        }
+        write(map)
+        writeTombstones(emptyMap())
+    }
+
     fun get(provider: String, contentId: String): AnilistTitleLink? =
         contentId.takeIf { it.isNotBlank() }?.let { read()[keyFor(provider, it)] }
 
@@ -41,11 +115,16 @@ class AnilistLinkStore(context: Context, private val gson: Gson = Gson()) {
 
     fun save(link: AnilistTitleLink) {
         if (link.contentId.isBlank() || link.mediaId <= 0) return
-        write(read() + (keyFor(link.provider, link.contentId) to link))
+        val key = keyFor(link.provider, link.contentId)
+        write(read() + (key to link))
+        // A re-link supersedes any pending unlink of the same title.
+        writeTombstones(readTombstones() - key)
     }
 
     fun remove(provider: String, contentId: String) {
-        write(read() - keyFor(provider, contentId))
+        val key = keyFor(provider, contentId)
+        write(read() - key)
+        writeTombstones(readTombstones() + (key to System.currentTimeMillis()))
     }
 
     /** Every link, newest first — for a "linked titles" screen. */
@@ -65,6 +144,17 @@ class AnilistLinkStore(context: Context, private val gson: Gson = Gson()) {
     companion object {
         private const val FILE = "sozo_anilist_links"
         private const val KEY_LINKS = "links"
+        private const val KEY_TOMBSTONES = "tombstones"
+
+        /** UTC, milliseconds — the format the server's `new Date(...)` parses without surprises. */
+        private fun formatter() = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+            .apply { timeZone = TimeZone.getTimeZone("UTC") }
+
+        fun isoOf(millis: Long): String = formatter().format(Date(millis))
+
+        fun parseIso(value: String?): Long =
+            value?.let { runCatching { formatter().parse(it)?.time }.getOrNull() }
+                ?: System.currentTimeMillis()
 
         /**
          * The identity of a local title. Trimmed and lowercased so an id that
@@ -89,4 +179,18 @@ data class AnilistTitleLink(
      * Surfaced in the UI so a wrong automatic guess is visibly a guess.
      */
     val auto: Boolean = false,
+)
+
+/** One row as the account stores it. Nullable throughout — it is server JSON. */
+data class RemoteTitleLink(
+    val key: String? = null,
+    val provider: String? = null,
+    val contentId: String? = null,
+    val mediaId: Int? = null,
+    val title: String? = null,
+    val coverImage: String? = null,
+    val totalEpisodes: Int? = null,
+    val auto: Boolean? = null,
+    val updatedAt: String? = null,
+    val deletedAt: String? = null,
 )

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistLinkStore.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistLinkStore.kt
@@ -1,0 +1,92 @@
+package com.saikou.sozo_tv.data.repository
+
+import android.content.Context
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+/**
+ * Remembers which AniList title a locally-watched title corresponds to.
+ *
+ * This mapping is the whole reason tracking works for sources AniList has never
+ * heard of. A CloudStream or Aniyomi extension gives us a title string and a
+ * content id; AniList wants a numeric media id. Nothing in either can derive the
+ * other, so the association is stored once — by the user, or by an exact title
+ * match — and reused for every episode after that.
+ *
+ * Keyed by provider AND content id: the same show carried by two sources is two
+ * separate links, because the episode numbering often differs between them.
+ */
+class AnilistLinkStore(context: Context, private val gson: Gson = Gson()) {
+
+    private val prefs = context.getSharedPreferences(FILE, Context.MODE_PRIVATE)
+    private val mapType = object : TypeToken<Map<String, AnilistTitleLink>>() {}.type
+
+    private fun read(): Map<String, AnilistTitleLink> {
+        val raw = prefs.getString(KEY_LINKS, null) ?: return emptyMap()
+        // A corrupt value is treated as empty rather than crashing every lookup —
+        // this is read on the playback path.
+        return runCatching { gson.fromJson<Map<String, AnilistTitleLink>>(raw, mapType) }
+            .getOrNull() ?: emptyMap()
+    }
+
+    private fun write(all: Map<String, AnilistTitleLink>) {
+        prefs.edit().putString(KEY_LINKS, gson.toJson(all)).apply()
+    }
+
+    fun get(provider: String, contentId: String): AnilistTitleLink? =
+        contentId.takeIf { it.isNotBlank() }?.let { read()[keyFor(provider, it)] }
+
+    fun mediaIdFor(provider: String, contentId: String): Int? =
+        get(provider, contentId)?.mediaId?.takeIf { it > 0 }
+
+    fun save(link: AnilistTitleLink) {
+        if (link.contentId.isBlank() || link.mediaId <= 0) return
+        write(read() + (keyFor(link.provider, link.contentId) to link))
+    }
+
+    fun remove(provider: String, contentId: String) {
+        write(read() - keyFor(provider, contentId))
+    }
+
+    /** Every link, newest first — for a "linked titles" screen. */
+    fun all(): List<AnilistTitleLink> = read().values.sortedByDescending { it.linkedAt }
+
+    /**
+     * Drops every link.
+     *
+     * Called on sign-out and on disconnect: these describe what one account
+     * watches and where, and leaving them behind would attribute the next
+     * person's viewing to a stranger's AniList list.
+     */
+    fun clear() {
+        prefs.edit().clear().apply()
+    }
+
+    companion object {
+        private const val FILE = "sozo_anilist_links"
+        private const val KEY_LINKS = "links"
+
+        /**
+         * The identity of a local title. Trimmed and lowercased so an id that
+         * differs only in case does not create a second, unlinked entry.
+         */
+        fun keyFor(provider: String, contentId: String): String =
+            "${provider.trim().lowercase()}|${contentId.trim().lowercase()}"
+    }
+}
+
+/** One local title tied to one AniList media id. */
+data class AnilistTitleLink(
+    val provider: String,
+    val contentId: String,
+    val mediaId: Int,
+    val title: String,
+    val coverImage: String? = null,
+    val totalEpisodes: Int? = null,
+    val linkedAt: Long = 0,
+    /**
+     * True when the match was made by title rather than chosen by the user.
+     * Surfaced in the UI so a wrong automatic guess is visibly a guess.
+     */
+    val auto: Boolean = false,
+)

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistRepository.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistRepository.kt
@@ -1,0 +1,138 @@
+package com.saikou.sozo_tv.data.repository
+
+import com.saikou.sozo_tv.data.remote.anilist.AnilistEntryState
+import com.saikou.sozo_tv.data.remote.anilist.AnilistException
+import com.saikou.sozo_tv.data.remote.anilist.AnilistGraphQlClient
+import com.saikou.sozo_tv.data.remote.anilist.AnilistLinkClient
+import com.saikou.sozo_tv.data.remote.anilist.AnilistListEntry
+import com.saikou.sozo_tv.data.remote.anilist.AnilistMedia
+import com.saikou.sozo_tv.data.remote.anilist.AnilistSaveResult
+import com.saikou.sozo_tv.data.remote.anilist.AnilistStatus
+import com.saikou.sozo_tv.data.remote.anilist.AnilistViewer
+import com.saikou.sozo_tv.data.remote.device.ApiResult
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Owns the AniList connection on this box.
+ *
+ * The connection is NOT made here. It is made once on the phone, stored against
+ * the Sozo account, and read from the account by [refresh] — which is what
+ * spares anyone from typing an AniList password with a d-pad. The consequence
+ * worth stating: this repository has no "connect" action at all, only a state
+ * that follows the account.
+ */
+class AnilistRepository(
+    private val linkClient: AnilistLinkClient,
+    private val api: AnilistGraphQlClient,
+    private val links: AnilistLinkStore,
+) {
+
+    private val _connection = MutableStateFlow<AnilistConnection>(AnilistConnection.Unknown)
+    val connection: StateFlow<AnilistConnection> = _connection.asStateFlow()
+
+    private val refreshMutex = Mutex()
+
+    @Volatile
+    private var token: String? = null
+
+    val accessToken: String? get() = token
+    val isConnected: Boolean get() = !token.isNullOrBlank()
+
+    /**
+     * Re-reads the link from the account.
+     *
+     * Serialised so a screen opening and a playback event cannot both refresh at
+     * once. Being offline leaves the previous state alone rather than reporting
+     * a disconnection that did not happen — a box that loses Wi-Fi for a minute
+     * must not stop tracking.
+     */
+    suspend fun refresh(): AnilistConnection = refreshMutex.withLock {
+        when (val result = linkClient.get()) {
+            is ApiResult.Ok -> {
+                val link = result.body
+                token = link?.accessToken
+                val state = link?.viewer()
+                    ?.let { AnilistConnection.Connected(it) }
+                    ?: AnilistConnection.NotConnected
+                _connection.value = state
+                state
+            }
+            // 401 means signed out of Sozo, which really is "no connection here".
+            is ApiResult.Http -> {
+                if (result.code == 401) {
+                    token = null
+                    _connection.value = AnilistConnection.NotConnected
+                }
+                _connection.value
+            }
+            is ApiResult.Network -> _connection.value
+        }
+    }
+
+    /** Removes the link from the ACCOUNT — every device loses it, not just this one. */
+    suspend fun disconnect(): Boolean {
+        val ok = linkClient.unlink() is ApiResult.Ok
+        token = null
+        _connection.value = AnilistConnection.NotConnected
+        links.clear()
+        return ok
+    }
+
+    /** Sign-out. Drops this box's copy without touching the account's link. */
+    fun forgetLocal() {
+        token = null
+        _connection.value = AnilistConnection.Unknown
+        links.clear()
+    }
+
+    /** The viewer's library. Throws when not connected, because a caller must not guess. */
+    suspend fun library(): List<AnilistListEntry> {
+        val token = token ?: throw AnilistException("AniList ulanmagan")
+        val viewer = (_connection.value as? AnilistConnection.Connected)?.viewer
+            ?: throw AnilistException("AniList hisobi aniqlanmadi")
+        return api.mediaList(token, viewer.id)
+    }
+
+    suspend fun entryState(mediaId: Int): AnilistEntryState? {
+        val token = token ?: return null
+        return api.entryState(token, mediaId)
+    }
+
+    suspend fun saveProgress(mediaId: Int, progress: Int, status: String?): AnilistSaveResult {
+        val token = token ?: throw AnilistException("AniList ulanmagan")
+        return api.saveProgress(token, mediaId, progress, status)
+    }
+
+    suspend fun search(query: String): List<AnilistMedia> = api.searchMedia(query)
+
+    /**
+     * The status to send alongside a progress write.
+     *
+     * Returns null — "leave it alone" — whenever the existing status already
+     * describes active viewing, so a rewatch stays REPEATING instead of being
+     * demoted to CURRENT.
+     */
+    fun statusFor(current: String?, episode: Int, total: Int?): String? = when {
+        current == AnilistStatus.REPEATING.value -> null
+        total != null && total > 0 && episode >= total -> AnilistStatus.COMPLETED.value
+        current == AnilistStatus.CURRENT.value -> null
+        else -> AnilistStatus.CURRENT.value
+    }
+}
+
+/**
+ * Three states, not two.
+ *
+ * [Unknown] exists because "we have not asked the account yet" and "the account
+ * has no AniList" look identical to a boolean, and showing "not connected" during
+ * the first request is a claim rather than a blank.
+ */
+sealed class AnilistConnection {
+    data object Unknown : AnilistConnection()
+    data object NotConnected : AnilistConnection()
+    data class Connected(val viewer: AnilistViewer) : AnilistConnection()
+}

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistRepository.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistRepository.kt
@@ -59,6 +59,7 @@ class AnilistRepository(
                     ?.let { AnilistConnection.Connected(it) }
                     ?: AnilistConnection.NotConnected
                 _connection.value = state
+                if (state is AnilistConnection.Connected) syncLinks()
                 state
             }
             // 401 means signed out of Sozo, which really is "no connection here".
@@ -70,6 +71,20 @@ class AnilistRepository(
                 _connection.value
             }
             is ApiResult.Network -> _connection.value
+        }
+    }
+
+    /**
+     * Exchanges this box's title->media map with the account.
+     *
+     * Silent on failure: it runs behind a screen opening or a playback event,
+     * neither of which the viewer is waiting on, and the local map plus its
+     * pending unlinks simply stay put until the next attempt.
+     */
+    suspend fun syncLinks() {
+        when (val result = linkClient.syncLinks(links.pendingChanges())) {
+            is ApiResult.Ok -> links.applyRemote(result.body)
+            else -> Unit
         }
     }
 

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistSourceRegistry.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistSourceRegistry.kt
@@ -1,0 +1,64 @@
+package com.saikou.sozo_tv.data.repository
+
+import android.content.Context
+
+/**
+ * Which installed sources address their content by AniList id.
+ *
+ * Some providers report the AniList entry a page corresponds to; most do not.
+ * That distinction matters more than it looks:
+ *
+ *   - a source that reports an id can be tracked EXACTLY. No title
+ *     normalisation, no season ambiguity, no chance of filing episodes into the
+ *     wrong show — the provider has already told us which entry this is.
+ *   - a source that does not falls back to matching by title, which is strict
+ *     on purpose and therefore often declines to match at all.
+ *
+ * The list is OBSERVED, not declared. There is no manifest anywhere saying
+ * which extensions support this, and a hardcoded list would be wrong the day
+ * after it was written — repos add and update providers constantly. So a
+ * provider is recorded the first time it actually reports an id, and the record
+ * is what the UI badges.
+ *
+ * The consequence worth stating: a source appears here only after the user has
+ * opened one title on it. That is the honest state — before then, nobody knows.
+ */
+class AnilistSourceRegistry(context: Context) {
+
+    private val prefs = context.getSharedPreferences(FILE, Context.MODE_PRIVATE)
+
+    /** Provider ids (`cs:…` / `an:…`) known to report AniList ids. */
+    fun all(): Set<String> = prefs.getStringSet(KEY_PROVIDERS, emptySet()).orEmpty()
+
+    fun supports(providerId: String): Boolean = providerId.trim() in all()
+
+    /**
+     * Records that [providerId] reported an AniList id.
+     *
+     * Idempotent, and cheap enough to call on every detail load — which is what
+     * keeps the list current as repos update their providers.
+     */
+    fun remember(providerId: String) {
+        val id = providerId.trim()
+        if (id.isEmpty() || id in all()) return
+        prefs.edit().putStringSet(KEY_PROVIDERS, all() + id).apply()
+    }
+
+    /**
+     * Forgets a provider.
+     *
+     * Used when an extension is removed: a stale badge on a source the user no
+     * longer has installed is a small lie, and the set is rebuilt for free the
+     * next time the provider is used.
+     */
+    fun forget(providerId: String) {
+        val id = providerId.trim()
+        if (id !in all()) return
+        prefs.edit().putStringSet(KEY_PROVIDERS, all() - id).apply()
+    }
+
+    private companion object {
+        const val FILE = "sozo_anilist_sources"
+        const val KEY_PROVIDERS = "providers"
+    }
+}

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistSourceRegistry.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistSourceRegistry.kt
@@ -44,18 +44,11 @@ class AnilistSourceRegistry(context: Context) {
         prefs.edit().putStringSet(KEY_PROVIDERS, all() + id).apply()
     }
 
-    /**
-     * Forgets a provider.
-     *
-     * Used when an extension is removed: a stale badge on a source the user no
-     * longer has installed is a small lie, and the set is rebuilt for free the
-     * next time the provider is used.
-     */
-    fun forget(providerId: String) {
-        val id = providerId.trim()
-        if (id !in all()) return
-        prefs.edit().putStringSet(KEY_PROVIDERS, all() - id).apply()
-    }
+    // No remove/clear on purpose. The set is only ever read to decorate
+    // providers that are currently installed, so an entry for an extension the
+    // user deleted matches nothing and shows nothing. Pruning it would be
+    // bookkeeping with no observable effect, and an unused method that claims
+    // otherwise is worse than none.
 
     private companion object {
         const val FILE = "sozo_anilist_sources"

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistTracker.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/AnilistTracker.kt
@@ -1,0 +1,201 @@
+package com.saikou.sozo_tv.data.repository
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Turns "an episode finished playing" into "AniList knows about it".
+ *
+ * Sits between the player and [AnilistRepository] because deciding WHETHER to
+ * write is the hard part, not the write itself. Three rules govern it, and all
+ * three exist to protect a list the user curated by hand:
+ *
+ *   1. never write to a title the user has not linked (or that did not match
+ *      exactly) — a wrong media id silently rewrites the wrong show;
+ *   2. never move progress backwards — a rewatch, or a phone that is further
+ *      ahead, must not undo real progress;
+ *   3. never surface a failure — this runs during playback, on a screen with no
+ *      room for an error and no keyboard to answer it with.
+ *
+ * Mirrors the mobile app's tracker deliberately: the two write to one AniList
+ * account, and a rule enforced on only one of them is not a rule.
+ */
+class AnilistTracker(
+    private val repository: AnilistRepository,
+    private val links: AnilistLinkStore,
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val mutex = Mutex()
+
+    /**
+     * Titles already looked up and found to have no confident match, so a
+     * hopeless auto-match is not retried on every single episode.
+     */
+    private val autoMatchFailed = HashSet<String>()
+
+    val isConnected: Boolean get() = repository.isConnected
+
+    /**
+     * Makes sure the connection has been read from the account at least once.
+     *
+     * The player can reach an episode's 85% mark before any screen has asked the
+     * account about AniList — on a cold start straight into playback from the
+     * Home rail, that is the normal case, not an edge one. Without this the first
+     * episode of every session would be silently dropped.
+     */
+    private suspend fun ensureConnected() {
+        if (repository.connection.value is AnilistConnection.Unknown) {
+            runCatching { repository.refresh() }
+        }
+    }
+
+    /**
+     * Fire-and-forget report from the player.
+     *
+     * Runs on the tracker's own scope, not the player's: the player is often
+     * being torn down at exactly the moment the last episode completes, and a
+     * coroutine on its scope would be cancelled before the request left the box.
+     */
+    fun reportEpisodeAsync(
+        provider: String,
+        contentId: String,
+        title: String,
+        episodeNumber: Int,
+    ): Job = scope.launch {
+        runCatching { reportEpisode(provider, contentId, title, episodeNumber) }
+            .onFailure { Log.w(TAG, "report failed: ${it.message}") }
+    }
+
+    /**
+     * Records that [episodeNumber] of a local title has been watched.
+     *
+     * Returns the media id it wrote to, or null when nothing was written — which
+     * is the common and correct outcome for an unlinked title.
+     */
+    suspend fun reportEpisode(
+        provider: String,
+        contentId: String,
+        title: String,
+        episodeNumber: Int,
+    ): Int? = mutex.withLock {
+        if (episodeNumber <= 0 || contentId.isBlank()) return null
+        ensureConnected()
+        if (!isConnected) return null
+
+        val mediaId = resolveMediaId(provider, contentId, title) ?: return null
+        return if (write(mediaId, episodeNumber)) mediaId else null
+    }
+
+    /** An existing link first, then an exact title match. */
+    private suspend fun resolveMediaId(
+        provider: String,
+        contentId: String,
+        title: String,
+    ): Int? {
+        links.mediaIdFor(provider, contentId)?.let { return it }
+
+        val key = AnilistLinkStore.keyFor(provider, contentId)
+        if (key in autoMatchFailed) return null
+
+        val match = findExactMatch(title)
+        if (match == null) {
+            autoMatchFailed.add(key)
+            return null
+        }
+
+        links.save(
+            AnilistTitleLink(
+                provider = provider,
+                contentId = contentId,
+                mediaId = match.id,
+                title = match.displayTitle,
+                coverImage = match.coverImage,
+                totalEpisodes = match.episodes,
+                linkedAt = System.currentTimeMillis(),
+                auto = true,
+            )
+        )
+        return match.id
+    }
+
+    /**
+     * Searches AniList and returns a result only when one of its titles matches
+     * [title] EXACTLY once normalized.
+     *
+     * Deliberately strict. A fuzzy "best result" would attach season 2 to season
+     * 1, or a recap film to the series, and then quietly write episode numbers
+     * into it for months. When there is no exact match the user is asked instead
+     * — being unlinked is recoverable, being wrongly linked is not obvious.
+     */
+    suspend fun findExactMatch(title: String): com.saikou.sozo_tv.data.remote.anilist.AnilistMedia? {
+        val wanted = normalizeTitle(title)
+        if (wanted.isEmpty()) return null
+        return runCatching {
+            repository.search(title).firstOrNull { media ->
+                media.searchTitles.any { normalizeTitle(it) == wanted }
+            }
+        }.onFailure { Log.w(TAG, "auto-match failed for \"$title\": ${it.message}") }
+            .getOrNull()
+    }
+
+    /** Reads the account's position, then writes only if this episode is genuinely ahead. */
+    private suspend fun write(mediaId: Int, episodeNumber: Int): Boolean = try {
+        val state = repository.entryState(mediaId)
+        if (state != null && episodeNumber <= state.progress) {
+            // Already at or beyond this episode — a rewatch, or the phone got
+            // here first. Writing would move the list backwards.
+            false
+        } else {
+            val result = repository.saveProgress(
+                mediaId = mediaId,
+                progress = episodeNumber,
+                status = repository.statusFor(state?.status, episodeNumber, state?.totalEpisodes),
+            )
+            Log.d(TAG, "media $mediaId -> episode ${result.progress} (${result.status})")
+            true
+        }
+    } catch (t: Throwable) {
+        // Playback must not be disturbed by a tracker outage.
+        Log.w(TAG, "write failed for media $mediaId: ${t.message}")
+        false
+    }
+
+    companion object {
+        private const val TAG = "AniListTracker"
+
+        /**
+         * Strips the noise that makes two names for the same show look different:
+         * case, punctuation, and the release tags source sites append.
+         */
+        fun normalizeTitle(raw: String): String {
+            var s = raw.lowercase().trim()
+            NOISE.forEach { s = it.replace(s, " ") }
+            // Punctuation is named rather than filtered with a Latin-only class:
+            // these titles are also Cyrillic and Japanese, and `[^a-z0-9]` would
+            // erase those scripts entirely and declare every one of them equal.
+            s = PUNCTUATION.replace(s, " ")
+            return s.trim().replace(WHITESPACE, " ")
+        }
+
+        /**
+         * Bracketed tags (`[1080p]`, `(TV)`), quality markers and dub/sub labels —
+         * all of which appear in source-site titles and never in an AniList one.
+         */
+        private val NOISE = listOf(
+            Regex("""\[[^]]*]"""),
+            Regex("""\([^)]*\)"""),
+            Regex("""\b(1080p|720p|480p|4k|hd|fhd|bluray|bd|web-?dl|hevc|x26[45])\b"""),
+            Regex("""\b(sub|dub|subbed|dubbed|uzbek|uzbekcha|tarjima|rus|russian)\b"""),
+        )
+
+        private val PUNCTUATION = Regex("""[.,:;!?'"`~@#${'$'}%^&*_+=<>/\\|{}\[\]()·・…—–-]+""")
+        private val WHITESPACE = Regex("""\s+""")
+    }
+}

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/DetailRepositoryImpl.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/DetailRepositoryImpl.kt
@@ -20,6 +20,8 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class DetailRepositoryImpl(
     private val engine: ExtensionEngine,
+    private val links: AnilistLinkStore,
+    private val sourceRegistry: AnilistSourceRegistry,
 ) : DetailRepository {
 
     private val cache = ConcurrentHashMap<Int, ExtDetail>()
@@ -29,7 +31,46 @@ class DetailRepositoryImpl(
         val entry = ExtensionContentRegistry.resolve(id) ?: return null
         val detail = engine.load(entry.provider, entry.url) ?: return null
         cache[id] = detail
+        recordAnilistId(detail)
         return detail
+    }
+
+    /**
+     * Takes the AniList id straight from the provider, when it offers one.
+     *
+     * This is the difference between exact tracking and guessing. A provider
+     * that reports its AniList id has told us precisely which entry the page IS
+     * — no title normalisation, no season ambiguity, no chance of filing
+     * episodes into the wrong show. Writing it into the link store here means
+     * the player needs no new plumbing: the tracker finds it by the ordinary
+     * lookup, exactly as it would find one the user made by hand.
+     *
+     * `auto = false` on purpose. The flag means "we guessed"; this is not a
+     * guess, and the UI must not label it as one.
+     *
+     * Only ever ADDS a link. A user who deliberately re-pointed a title at a
+     * different entry must not have that overwritten by the source on the next
+     * page load.
+     */
+    private fun recordAnilistId(detail: ExtDetail) {
+        val mediaId = detail.anilistId ?: return
+        if (mediaId <= 0) return
+
+        sourceRegistry.remember(detail.provider)
+        if (links.mediaIdFor(detail.provider, detail.contentUrl) != null) return
+
+        links.save(
+            AnilistTitleLink(
+                provider = detail.provider,
+                contentId = detail.contentUrl,
+                mediaId = mediaId,
+                title = detail.title,
+                coverImage = detail.thumbnail,
+                totalEpisodes = detail.episodes.size.takeIf { it > 0 },
+                linkedAt = System.currentTimeMillis(),
+                auto = false,
+            )
+        )
     }
 
     private suspend fun detailResult(id: Int): Result<DetailModel> {

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/SearchRepositoryImpl.kt
@@ -4,6 +4,9 @@ import com.saikou.sozo_tv.data.extensions.ExtensionEngine
 import com.saikou.sozo_tv.data.extensions.toSearchModel
 import com.saikou.sozo_tv.domain.model.SearchModel
 import com.saikou.sozo_tv.domain.repository.SearchRepository
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.Flow
+import com.saikou.sozo_tv.domain.repository.SearchSourceLeg
 
 /** Search delegates to the active provider's `search()`. */
 class SearchRepositoryImpl(
@@ -26,9 +29,13 @@ class SearchRepositoryImpl(
     // No "no source selected" failure here on purpose: a global search does not
     // depend on one being active, and an empty corpus is an empty RESULT, not an
     // error the UI should render as a crash banner.
-    override suspend fun searchAllSources(query: String): Result<List<SearchModel>> = try {
-        Result.success(engine.searchAll(query).map { it.toSearchModel() })
-    } catch (e: Exception) {
-        Result.failure(e)
-    }
+    override fun searchAllSources(query: String): Flow<SearchSourceLeg> =
+        engine.searchAllFlow(query).map { leg ->
+            SearchSourceLeg(
+                providerId = leg.provider.id,
+                providerName = leg.provider.name,
+                items = leg.items.map { it.toSearchModel() },
+                status = leg.status,
+            )
+        }
 }

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/WatchHistorySyncRepository.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/WatchHistorySyncRepository.kt
@@ -197,13 +197,19 @@ class WatchHistorySyncRepository(
     // ─── mapping ─────────────────────────────────────────────────────────────
 
     private fun WatchHistoryEntity.toSyncItem() = HistorySyncItem(
-        provider = source.ifBlank { currentSourceName },
+        provider = syncProvider(),
         contentId = categoryid,
         contentUrl = videoUrl,
         title = mediaName.ifBlank { title },
         thumbnail = image,
         isSerial = isSeries,
         episodeIndex = epIndex.takeIf { it >= 0 },
+        // The phone sends a 1-based episode NUMBER and the server keys on
+        // `episodeNumber ?? episodeIndex`. Sending only the 0-based index meant
+        // this box's episode 1 was keyed `e0` against the phone's `e1` — two rows
+        // for one episode that could never reconcile. The TV already calls this
+        // "Episode ${epIndex + 1}" everywhere it shows one.
+        episodeNumber = epIndex.takeIf { it >= 0 }?.plus(1),
         positionMs = lastPosition,
         durationMs = totalDuration,
         watchedAt = isoOf(watchedAt),
@@ -230,6 +236,7 @@ class WatchHistorySyncRepository(
             "isSeries" to isSeries,
             "source" to source,
             "currentSourceName" to currentSourceName,
+            "providerId" to providerId,
         ),
     )
 
@@ -262,6 +269,7 @@ class WatchHistorySyncRepository(
             isSeries = e["isSeries"] as? Boolean ?: false,
             source = str("source").orEmpty(),
             currentSourceName = str("currentSourceName").orEmpty(),
+            providerId = str("providerId").orEmpty(),
         )
     }
 
@@ -269,16 +277,33 @@ class WatchHistorySyncRepository(
         parseIso(watchedAt).takeIf { it > 0 } ?: System.currentTimeMillis()
 
     /**
+     * The provider string this row syncs under.
+     *
+     * [WatchHistoryEntity.providerId] is the real one (`cs:`/`an:`, prefixed
+     * exactly as the phone prefixes it). `source` is only a routing sentinel —
+     * the literal string "extension" for every extension provider — so falling
+     * back to it means a row keeps the identity it already had on the server.
+     * Rows written before providerId existed are the only ones that land there.
+     */
+    private fun WatchHistoryEntity.syncProvider(): String =
+        providerId.ifBlank { source.ifBlank { currentSourceName } }.trim()
+
+    /**
      * Mirrors the server's buildHistoryKey EXACTLY. Drifting from it splits one
      * episode into two rows that never reconcile, so the two must change together.
+     *
+     * The episode segment uses the 1-based NUMBER, matching what [toSyncItem]
+     * sends and what the phone sends. Rows already on the server under the old
+     * 0-based key are re-keyed once and then agree; history is capped and the
+     * stale keys age out.
      */
     private fun WatchHistoryEntity.syncKey(): String? {
-        val provider = source.ifBlank { currentSourceName }.trim()
+        val provider = syncProvider()
         val base = (categoryid?.takeIf { it.isNotBlank() } ?: videoUrl).trim()
         if (base.isEmpty()) return null
         val head = "$provider|$base"
         if (!isSeries) return head
-        return if (epIndex < 0) head else "$head|e$epIndex"
+        return if (epIndex < 0) head else "$head|e${epIndex + 1}"
     }
 
     private companion object {

--- a/app/src/main/java/com/saikou/sozo_tv/di/koinModule.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/di/koinModule.kt
@@ -93,7 +93,7 @@ val koinModule = module {
         CategoriesRepositoryImpl(engine = get())
     }
     single<DetailRepository> {
-        DetailRepositoryImpl(engine = get())
+        DetailRepositoryImpl(engine = get(), links = get(), sourceRegistry = get())
     }
     viewModel { HomeViewModel(repo = get(), imdbRepo = get(), historyRepository = get()) }
     viewModel { TvGardenViewModel(get()) }

--- a/app/src/main/java/com/saikou/sozo_tv/di/koinModule.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/di/koinModule.kt
@@ -2,7 +2,10 @@ package com.saikou.sozo_tv.di
 
 import androidx.room.Room
 import com.google.firebase.database.FirebaseDatabase
+import com.saikou.sozo_tv.data.repository.AnilistRepository
+import com.saikou.sozo_tv.presentation.viewmodel.AnilistViewModel
 import com.saikou.sozo_tv.data.local.database.AppDatabase
+import com.saikou.sozo_tv.data.local.database.MIGRATION_1_2
 import com.saikou.sozo_tv.data.local.pref.PreferenceManager
 import com.saikou.sozo_tv.data.repository.CategoriesRepositoryImpl
 import com.saikou.sozo_tv.data.repository.CharacterBookmarkRepositoryImpl
@@ -52,7 +55,7 @@ val koinModule = module {
     single {
         Room.databaseBuilder(
             androidApplication(), AppDatabase::class.java, "movie_database"
-        ).build()
+        ).addMigrations(MIGRATION_1_2).build()
     }
     single { get<AppDatabase>().movieDao() }
     single { get<AppDatabase>().tvDao() }
@@ -97,8 +100,9 @@ val koinModule = module {
     viewModel { EpisodeViewModel(watchHistoryRepository = get()) }
     viewModel { WrongTitleViewModel() }
     viewModel { UpdateViewModel() }
+    viewModel { AnilistViewModel(repository = get()) }
     viewModel { ViewAllViewModel(get()) }
-    viewModel { SettingsViewModel(get(), profileRepo = get(), deviceAuth = get(), userLists = get(), historySync = get()) }
+    viewModel { SettingsViewModel(get(), profileRepo = get(), deviceAuth = get(), userLists = get(), historySync = get(), anilist = get()) }
     viewModel { LiveTvViewModel(dao = get()) }
     viewModel { SplashViewModel(firebaseService = get()) }
     viewModel { PlayAnimeViewModel(watchHistoryRepository = get(), historySync = get()) }

--- a/app/src/main/java/com/saikou/sozo_tv/di/networkModule.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/di/networkModule.kt
@@ -5,9 +5,14 @@ import com.google.gson.GsonBuilder
 import com.saikou.sozo_tv.BuildConfig
 import com.saikou.sozo_tv.data.local.pref.DeviceSessionStore
 import com.saikou.sozo_tv.data.extensions.ExtensionEngine
+import com.saikou.sozo_tv.data.remote.anilist.AnilistGraphQlClient
+import com.saikou.sozo_tv.data.remote.anilist.AnilistLinkClient
 import com.saikou.sozo_tv.data.remote.device.DeviceAuthClient
 import com.saikou.sozo_tv.data.remote.history.WatchHistorySyncClient
 import com.saikou.sozo_tv.data.remote.lists.UserListsClient
+import com.saikou.sozo_tv.data.repository.AnilistLinkStore
+import com.saikou.sozo_tv.data.repository.AnilistRepository
+import com.saikou.sozo_tv.data.repository.AnilistTracker
 import com.saikou.sozo_tv.data.repository.DeviceAuthRepository
 import com.saikou.sozo_tv.data.repository.UserListsRepository
 import com.saikou.sozo_tv.data.repository.WatchHistorySyncRepository
@@ -69,6 +74,25 @@ val NetworkModule = module {
             local = get(),
         )
     }
+
+    // AniList. This box never runs the OAuth handshake: the phone connects once,
+    // the token is stored against the Sozo account, and the TV reads it from
+    // there. An OAuth flow here would mean typing an AniList password with a
+    // d-pad, which is the problem the backend exchange exists to avoid.
+    single {
+        AnilistLinkClient(
+            okHttpClient = get(named("authOkHttp")),
+            gson = get(),
+            baseUrl = BuildConfig.SOZO_API_BASE_URL,
+            tokenProvider = { get<DeviceAuthRepository>().accessToken() },
+        )
+    }
+    // Platform TLS again — the app's content client trusts any certificate, and
+    // must never carry someone's AniList token.
+    single { AnilistGraphQlClient(okHttpClient = get(named("authOkHttp"))) }
+    single { AnilistLinkStore(context = androidContext()) }
+    single { AnilistRepository(linkClient = get(), api = get(), links = get()) }
+    single { AnilistTracker(repository = get(), links = get()) }
 
 }
 

--- a/app/src/main/java/com/saikou/sozo_tv/di/networkModule.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/di/networkModule.kt
@@ -12,6 +12,7 @@ import com.saikou.sozo_tv.data.remote.history.WatchHistorySyncClient
 import com.saikou.sozo_tv.data.remote.lists.UserListsClient
 import com.saikou.sozo_tv.data.repository.AnilistLinkStore
 import com.saikou.sozo_tv.data.repository.AnilistRepository
+import com.saikou.sozo_tv.data.repository.AnilistSourceRegistry
 import com.saikou.sozo_tv.data.repository.AnilistTracker
 import com.saikou.sozo_tv.data.repository.DeviceAuthRepository
 import com.saikou.sozo_tv.data.repository.UserListsRepository
@@ -91,6 +92,7 @@ val NetworkModule = module {
     // must never carry someone's AniList token.
     single { AnilistGraphQlClient(okHttpClient = get(named("authOkHttp"))) }
     single { AnilistLinkStore(context = androidContext()) }
+    single { AnilistSourceRegistry(context = androidContext()) }
     single { AnilistRepository(linkClient = get(), api = get(), links = get()) }
     single { AnilistTracker(repository = get(), links = get()) }
 

--- a/app/src/main/java/com/saikou/sozo_tv/domain/repository/SearchRepository.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/domain/repository/SearchRepository.kt
@@ -1,15 +1,33 @@
 package com.saikou.sozo_tv.domain.repository
 
 import com.saikou.sozo_tv.domain.model.SearchModel
+import com.saikou.sozo_tv.data.extensions.SearchLegStatus
+import kotlinx.coroutines.flow.Flow
 
 interface SearchRepository {
     suspend fun searchAnime(query: String): Result<List<SearchModel>>
     suspend fun searchMovie(query: String): Result<List<SearchModel>>
 
     /**
-     * Search every installed source instead of just the active one. Bounded and
-     * failure-tolerant in the engine, so this returns whatever answered in time
-     * rather than failing when one source is down.
+     * Search every installed source instead of just the active one.
+     *
+     * A Flow, not a Result: legs arrive one per source as they answer. Waiting
+     * for the whole set meant one dead mirror held the screen blank for the full
+     * timeout while eight other sources had already replied.
      */
-    suspend fun searchAllSources(query: String): Result<List<SearchModel>>
+    fun searchAllSources(query: String): Flow<SearchSourceLeg>
 }
+
+/**
+ * One source's answer, in domain terms.
+ *
+ * [status] is carried rather than collapsing a failure into an empty list: a
+ * broken source and a source with no match look identical otherwise, and only
+ * one of them is worth retrying.
+ */
+data class SearchSourceLeg(
+    val providerId: String,
+    val providerName: String,
+    val items: List<SearchModel>,
+    val status: SearchLegStatus,
+)

--- a/app/src/main/java/com/saikou/sozo_tv/engine/cloudstream/PluginHost.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/engine/cloudstream/PluginHost.kt
@@ -378,6 +378,21 @@ class PluginHost(private val appContext: Context) {
                 })
             }
         }
+        // Tracker ids the provider itself supplied.
+        //
+        // This is the difference between exact tracking and guessing. A provider
+        // that calls addAniListId() is telling us precisely which AniList entry
+        // this page IS — no title normalisation, no season ambiguity, no chance
+        // of filing episodes into the wrong show. Only some providers do it,
+        // which is why the app still has a title matcher for the rest.
+        val syncIds = JSONObject()
+        runCatching {
+            resp.syncData.forEach { (name, value) ->
+                val id = value.trim().toIntOrNull() ?: return@forEach
+                if (id > 0) syncIds.put(name.lowercase(), id)
+            }
+        }
+
         // Cast (actors) + related (recommendations) when the provider supplies them.
         val cast = JSONArray()
         (resp.actors ?: emptyList()).forEach { ad ->
@@ -415,6 +430,7 @@ class PluginHost(private val appContext: Context) {
             put("genres", JSONArray(resp.tags ?: emptyList<String>()))
             put("type", resp.type.name)
             put("isSerial", isSerial)
+            if (syncIds.length() > 0) put("syncIds", syncIds)
             put("cast", cast)
             put("related", related)
             put("episodes", episodes)

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/activities/MainActivity.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/activities/MainActivity.kt
@@ -79,7 +79,12 @@ class MainActivity : AppCompatActivity() {
             intent.removeExtra(EXTRA_SEARCH_QUERY)
             navController.navigate(
                 R.id.search,
-                Bundle().apply { putString(SearchScreen.ARG_QUERY, query) },
+                Bundle().apply {
+                    putString(SearchScreen.ARG_QUERY, query)
+                    // The only caller is AniList's "find in sources", which is
+                    // asking which of the installed sources carries this title.
+                    putBoolean(SearchScreen.ARG_SEARCH_ALL, true)
+                },
             )
         }
 

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/activities/MainActivity.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/activities/MainActivity.kt
@@ -3,6 +3,7 @@ package com.saikou.sozo_tv.presentation.activities
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import com.saikou.sozo_tv.presentation.screens.search.SearchScreen
 import android.util.Log
 import android.view.View
 import androidx.appcompat.app.AppCompatDelegate
@@ -70,6 +71,18 @@ class MainActivity : AppCompatActivity() {
 
         binding.navMain.setupWithNavController(navController)
 
+        // A query handed over from another activity (the AniList screen's "find in
+        // sources"). Consumed rather than read: this activity is often reached
+        // through singleTop, and leaving the extra on the intent would re-open
+        // search on every later return to Home.
+        intent?.getStringExtra(EXTRA_SEARCH_QUERY)?.takeIf { it.isNotBlank() }?.let { query ->
+            intent.removeExtra(EXTRA_SEARCH_QUERY)
+            navController.navigate(
+                R.id.search,
+                Bundle().apply { putString(SearchScreen.ARG_QUERY, query) },
+            )
+        }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             binding.navMainFragment.isFocusedByDefault = true
         }
@@ -132,4 +145,10 @@ class MainActivity : AppCompatActivity() {
         _binding = null
         headerBinding = null
     }
+
+    companion object {
+        /** Intent extra carrying a search query from another activity. */
+        const val EXTRA_SEARCH_QUERY = "sozo.extra.SEARCH_QUERY"
+    }
+
 }

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/activities/ProfileActivity.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/activities/ProfileActivity.kt
@@ -235,6 +235,14 @@ class ProfileActivity : AppCompatActivity(), MyAccountPage.AuthNavigator {
                         NavOptions.Builder().setPopUpTo(R.id.newsPage, true).build()
                     )
                 }
+
+                5 -> {
+                    if (currentPageId != R.id.anilistScreen) navController.navigate(
+                        R.id.anilistScreen,
+                        null,
+                        NavOptions.Builder().setPopUpTo(R.id.anilistScreen, true).build()
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/anilist/AnilistEntryDialog.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/anilist/AnilistEntryDialog.kt
@@ -17,7 +17,9 @@ import com.saikou.sozo_tv.data.remote.anilist.AnilistListEntry
 import com.saikou.sozo_tv.data.remote.anilist.AnilistStatus
 import com.saikou.sozo_tv.databinding.AnilistEntryDialogBinding
 import com.saikou.sozo_tv.presentation.viewmodel.AnilistViewModel
+import com.saikou.sozo_tv.utils.applyTvFocusScale
 import com.saikou.sozo_tv.utils.loadImage
+import com.saikou.sozo_tv.utils.requestInitialFocus
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
@@ -84,7 +86,12 @@ class AnilistEntryDialog : DialogFragment() {
             onSearchSources?.invoke(title)
         }
 
-        binding.btnBump.requestFocus()
+        binding.btnBump.applyTvFocusScale(scale = 1.02f)
+        binding.btnSearch.applyTvFocusScale(scale = 1.02f)
+        // Posted, not immediate: requestFocus() before the dialog window is laid
+        // out returns false, and the highlight ends up on whatever the framework
+        // picked first.
+        binding.btnBump.requestInitialFocus()
     }
 
     private fun currentEntry(): AnilistListEntry? =
@@ -114,8 +121,12 @@ class AnilistEntryDialog : DialogFragment() {
             next == null -> getString(R.string.anilist_caught_up)
             else -> getString(R.string.anilist_mark_watched, next)
         }
+        val wasFocused = binding.btnBump.hasFocus()
         binding.btnBump.isEnabled = !busy && next != null
-        binding.btnBump.alpha = if (binding.btnBump.isEnabled) 1f else 0.5f
+        // A disabled view is not focusable. Disabling the one under the cursor
+        // strands the remote, so hand focus to the next action rather than
+        // letting the framework drop it to the dialog root.
+        if (wasFocused && !binding.btnBump.isEnabled) binding.btnSearch.requestFocus()
 
         statusAdapter.setCounts(emptyMap())
         AnilistStatus.fromValue(entry.status)?.let { statusAdapter.setSelected(it) }

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/anilist/AnilistEntryDialog.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/anilist/AnilistEntryDialog.kt
@@ -1,0 +1,136 @@
+package com.saikou.sozo_tv.presentation.screens.anilist
+
+import android.annotation.SuppressLint
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.saikou.sozo_tv.R
+import com.saikou.sozo_tv.adapters.AnilistStatusAdapter
+import com.saikou.sozo_tv.data.remote.anilist.AnilistListEntry
+import com.saikou.sozo_tv.data.remote.anilist.AnilistStatus
+import com.saikou.sozo_tv.databinding.AnilistEntryDialogBinding
+import com.saikou.sozo_tv.presentation.viewmodel.AnilistViewModel
+import com.saikou.sozo_tv.utils.loadImage
+import kotlinx.coroutines.launch
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
+
+/**
+ * Everything you can do to one library entry, on one dialog.
+ *
+ * Re-reads the entry from the ViewModel on every state change instead of holding
+ * the copy it was opened with: the dialog stays up across a write, and a captured
+ * entry would keep showing the progress the user just changed.
+ */
+class AnilistEntryDialog : DialogFragment() {
+
+    private var _binding: AnilistEntryDialogBinding? = null
+    private val binding get() = _binding!!
+
+    private val model: AnilistViewModel by activityViewModel()
+
+    private val entryId: Int get() = arguments?.getInt(ARG_ENTRY_ID) ?: 0
+
+    private var onSearchSources: ((String) -> Unit)? = null
+
+    fun setOnSearchSources(listener: (String) -> Unit) {
+        onSearchSources = listener
+    }
+
+    private lateinit var statusAdapter: AnilistStatusAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = AnilistEntryDialogBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(0))
+        dialog?.window?.setWindowAnimations(R.style.DialogAnimation)
+
+        statusAdapter = AnilistStatusAdapter { status ->
+            currentEntry()?.let { model.setStatus(it, status) }
+        }
+        binding.statusRv.layoutManager =
+            LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
+        binding.statusRv.adapter = statusAdapter
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                model.state.collect { render() }
+            }
+        }
+
+        binding.btnBump.setOnClickListener {
+            val entry = currentEntry() ?: return@setOnClickListener
+            if (entry.nextEpisode == null) return@setOnClickListener
+            model.bumpEpisode(entry)
+        }
+
+        binding.btnSearch.setOnClickListener {
+            val title = currentEntry()?.media?.displayTitle ?: return@setOnClickListener
+            dismiss()
+            onSearchSources?.invoke(title)
+        }
+
+        binding.btnBump.requestFocus()
+    }
+
+    private fun currentEntry(): AnilistListEntry? =
+        model.state.value.entries.firstOrNull { it.id == entryId }
+
+    @SuppressLint("SetTextI18n")
+    private fun render() {
+        val entry = currentEntry() ?: run { dismissAllowingStateLoss(); return }
+        val media = entry.media
+        val busy = entry.id in model.state.value.busy
+
+        binding.entryTitle.text = media.displayTitle
+        binding.coverImage.loadImage(media.coverImage)
+
+        val parts = buildList {
+            add(AnilistStatus.fromValue(entry.status)?.label ?: entry.status)
+            add(media.episodes?.let { "${entry.progress} / $it" } ?: "${entry.progress}")
+            if (entry.behindBy > 0) add(getString(R.string.anilist_n_new, entry.behindBy))
+        }
+        binding.entryMeta.text = parts.joinToString("  •  ")
+
+        val next = entry.nextEpisode
+        binding.btnBump.text = when {
+            busy -> getString(R.string.anilist_saving)
+            // Caught up is stated rather than left as a button that does nothing —
+            // on a remote, a dead button just gets pressed harder.
+            next == null -> getString(R.string.anilist_caught_up)
+            else -> getString(R.string.anilist_mark_watched, next)
+        }
+        binding.btnBump.isEnabled = !busy && next != null
+        binding.btnBump.alpha = if (binding.btnBump.isEnabled) 1f else 0.5f
+
+        statusAdapter.setCounts(emptyMap())
+        AnilistStatus.fromValue(entry.status)?.let { statusAdapter.setSelected(it) }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        private const val ARG_ENTRY_ID = "entryId"
+
+        fun newInstance(entryId: Int) = AnilistEntryDialog().apply {
+            arguments = Bundle().apply { putInt(ARG_ENTRY_ID, entryId) }
+        }
+    }
+}

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/anilist/AnilistScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/anilist/AnilistScreen.kt
@@ -21,6 +21,8 @@ import com.saikou.sozo_tv.databinding.AnilistScreenBinding
 import com.saikou.sozo_tv.presentation.activities.MainActivity
 import com.saikou.sozo_tv.presentation.viewmodel.AnilistLibraryState
 import com.saikou.sozo_tv.presentation.viewmodel.AnilistViewModel
+import com.saikou.sozo_tv.utils.keepFocusAlive
+import com.saikou.sozo_tv.utils.requestInitialFocus
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
@@ -114,13 +116,31 @@ class AnilistScreen : Fragment() {
             else -> null
         }
 
-        binding.messageView.isVisible = message != null
-        binding.messageView.text = message.orEmpty()
-        binding.statusRv.isVisible = connection is AnilistConnection.Connected
-        binding.entriesRv.isVisible = message == null
+        // Android does NOT reassign focus when the focused view is hidden or its
+        // row is removed — from targetSdk 26 it clears focus to the root, and
+        // the remote goes dead. Both mutations below can do exactly that: the
+        // grid is hidden whenever a message replaces it, and submitList removes
+        // rows when the status filter changes.
+        binding.root.keepFocusAlive {
+            binding.messageView.isVisible = message != null
+            binding.messageView.text = message.orEmpty()
+            binding.statusRv.isVisible = connection is AnilistConnection.Connected
+            binding.entriesRv.isVisible = message == null
 
-        entryAdapter.submitList(state.visible)
+            entryAdapter.submitList(state.visible)
+        }
+
+        // First real content: put the highlight on the grid rather than leaving
+        // it wherever the framework left it, which is the status row and makes
+        // the screen look like a filter picker.
+        if (message == null && state.visible.isNotEmpty() && !hasPlacedInitialFocus) {
+            hasPlacedInitialFocus = true
+            binding.entriesRv.requestInitialFocus()
+        }
     }
+
+    /** One-shot: after this, focus is the user's to move. */
+    private var hasPlacedInitialFocus = false
 
     /**
      * Hands the title to the app's own search.

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/anilist/AnilistScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/anilist/AnilistScreen.kt
@@ -1,0 +1,148 @@
+package com.saikou.sozo_tv.presentation.screens.anilist
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.saikou.sozo_tv.R
+import com.saikou.sozo_tv.adapters.AnilistEntryAdapter
+import com.saikou.sozo_tv.adapters.AnilistStatusAdapter
+import com.saikou.sozo_tv.data.repository.AnilistConnection
+import com.saikou.sozo_tv.databinding.AnilistScreenBinding
+import com.saikou.sozo_tv.presentation.activities.MainActivity
+import com.saikou.sozo_tv.presentation.viewmodel.AnilistLibraryState
+import com.saikou.sozo_tv.presentation.viewmodel.AnilistViewModel
+import kotlinx.coroutines.launch
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
+
+/**
+ * The viewer's AniList library, filtered by status.
+ *
+ * There is no "connect" button here, and that is the design rather than an
+ * omission: the OAuth handshake happens on the phone, the token is stored on the
+ * Sozo account, and this box reads it. Asking someone to type an AniList password
+ * with a d-pad is the problem that arrangement exists to avoid — so when there is
+ * no connection, this screen says where to make one.
+ */
+class AnilistScreen : Fragment() {
+
+    private var _binding: AnilistScreenBinding? = null
+    private val binding get() = _binding!!
+
+    /**
+     * Scoped to the activity so [AnilistEntryDialog] shares it: the dialog writes
+     * progress and the grid behind it has to show the new number the moment the
+     * dialog closes.
+     */
+    private val model: AnilistViewModel by activityViewModel()
+
+    private val entryAdapter = AnilistEntryAdapter { entry ->
+        AnilistEntryDialog.newInstance(entry.id)
+            .also { it.setOnSearchSources(::searchInSources) }
+            .show(parentFragmentManager, "AnilistEntryDialog")
+    }
+
+    private lateinit var statusAdapter: AnilistStatusAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = AnilistScreenBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        statusAdapter = AnilistStatusAdapter { model.selectStatus(it) }
+        binding.statusRv.layoutManager =
+            LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
+        binding.statusRv.adapter = statusAdapter
+
+        binding.entriesRv.layoutManager = GridLayoutManager(requireContext(), GRID_COLUMNS)
+        binding.entriesRv.adapter = entryAdapter
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch { model.state.collect(::render) }
+                launch { model.connection.collect { renderConnection(it) } }
+                launch {
+                    model.messages.collect {
+                        Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        }
+
+        // Forced on every entry to this screen: the phone can connect or
+        // disconnect at any moment, and this box is never told about it.
+        model.load(force = true)
+    }
+
+    private fun renderConnection(connection: AnilistConnection) {
+        binding.viewerName.text = (connection as? AnilistConnection.Connected)?.viewer?.name.orEmpty()
+    }
+
+    private fun render(state: AnilistLibraryState) {
+        binding.loadingBar.isVisible = state.loading
+
+        statusAdapter.setCounts(state.counts)
+        statusAdapter.setSelected(state.status)
+
+        val connection = model.connection.value
+        val message = when {
+            // "Not asked yet" and "no AniList on this account" look identical to a
+            // boolean, and claiming the second during the first request is wrong.
+            state.loading && state.entries.isEmpty() -> null
+            connection is AnilistConnection.NotConnected -> getString(R.string.anilist_connect_on_phone)
+            state.error != null && state.entries.isEmpty() -> state.error
+            state.visible.isEmpty() && state.entries.isEmpty() ->
+                getString(R.string.anilist_library_empty)
+            state.visible.isEmpty() ->
+                getString(R.string.anilist_status_empty, state.status.label)
+            else -> null
+        }
+
+        binding.messageView.isVisible = message != null
+        binding.messageView.text = message.orEmpty()
+        binding.statusRv.isVisible = connection is AnilistConnection.Connected
+        binding.entriesRv.isVisible = message == null
+
+        entryAdapter.submitList(state.visible)
+    }
+
+    /**
+     * Hands the title to the app's own search.
+     *
+     * Search lives in MainActivity's graph and this screen lives in the profile
+     * one, so this crosses activities rather than navigating — which is also why
+     * the query travels as an intent extra instead of a nav argument.
+     */
+    private fun searchInSources(title: String) {
+        startActivity(
+            Intent(requireContext(), MainActivity::class.java)
+                .putExtra(MainActivity.EXTRA_SEARCH_QUERY, title)
+        )
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private companion object {
+        /** Poster columns. Six 150dp cards fit a 1080p TV without shrinking the art. */
+        const val GRID_COLUMNS = 6
+    }
+}

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
@@ -23,6 +23,9 @@ import androidx.annotation.OptIn
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import com.saikou.sozo_tv.data.extensions.ExtensionEngine
+import com.saikou.sozo_tv.data.repository.AnilistTracker
+import org.koin.android.ext.android.inject
 import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
@@ -93,6 +96,26 @@ class SeriesPlayerScreen : Fragment() {
     private var okHttpClient: OkHttpClient? = null
 
     private val model by viewModel<PlayAnimeViewModel>()
+
+    /** Which extension is actually playing — see WatchHistoryEntity.providerId. */
+    private val extensionEngine: ExtensionEngine by inject()
+
+    /**
+     * AniList write-back. Injected rather than reached through the ViewModel
+     * because it deliberately outlives this fragment: an episode completing is
+     * very often the moment the player is torn down.
+     */
+    private val anilistTracker: AnilistTracker by inject()
+
+    /**
+     * Episode numbers already reported to AniList for this playback session.
+     *
+     * The progress check runs on every position callback, and auto-advance means
+     * one fragment can cover several episodes — a plain flag would report the
+     * first episode and nothing after it.
+     */
+    private val anilistReported = HashSet<Int>()
+
     private lateinit var mediaSession: MediaSession
     private val args by navArgs<SeriesPlayerScreenArgs>()
     private val episodeList = arrayListOf<Data>()
@@ -229,12 +252,51 @@ class SeriesPlayerScreen : Fragment() {
                         if (remainingTime in 9001..10000 && !countdownShown && !isCountdownActive) {
                             showNextEpisodeCountdown()
                         }
+                        if (currentPosition >= duration * ANILIST_WATCHED_FRACTION) {
+                            reportToAnilist()
+                        }
                     }
                 }
                 progressHandler?.postDelayed(this, 1000)
             }
         }
         progressHandler?.post(progressRunnable!!)
+    }
+
+    /**
+     * Tells AniList this episode has been watched.
+     *
+     * Fires at [ANILIST_WATCHED_FRACTION] rather than at the end because viewers
+     * skip endings and next-episode previews; waiting for the last frame loses
+     * those episodes entirely. Runs from the one-second progress tick, so it is
+     * guarded by [anilistReported] — without that it would fire once per second
+     * for the rest of the episode.
+     *
+     * Everything below is fire-and-forget. There is no error path on purpose:
+     * this happens mid-playback, on a screen with no room for a message and no
+     * keyboard to answer one with.
+     */
+    private fun reportToAnilist() {
+        // No connection check here on purpose: whether this box has read the
+        // account's AniList link yet is the tracker's problem, and asking on this
+        // thread would either block playback or answer "no" during a cold start.
+        val episodeNumber = model.currentEpIndex + 1
+        if (episodeNumber <= 0 || !anilistReported.add(episodeNumber)) return
+
+        val contentId = args.seriesMainId
+        if (contentId.isBlank()) {
+            // Nothing stable to key a link on; a link keyed on a URL that changes
+            // per session would be created fresh every time and never reused.
+            anilistReported.remove(episodeNumber)
+            return
+        }
+
+        anilistTracker.reportEpisodeAsync(
+            provider = extensionEngine.getActiveProvider().orEmpty(),
+            contentId = contentId,
+            title = args.name,
+            episodeNumber = episodeNumber,
+        )
     }
 
     private fun showNextEpisodeCountdown() {
@@ -978,7 +1040,14 @@ class SeriesPlayerScreen : Fragment() {
                     epIndex = model.currentEpIndex,
                     lastPosition = player.currentPosition,
                     videoUrl = series.urlobj,
-                    currentQualityIndex = model.currentSelectedVideoOptionIndex
+                    currentQualityIndex = model.currentSelectedVideoOptionIndex,
+                    // Backfill: rows written before providerId existed pick it up
+                    // the next time they are saved, rather than staying unmatchable
+                    // forever. Only ever filled in, never overwritten with a blank.
+                    providerId = getEpIndex.providerId
+                        .ifBlank { extensionEngine.getActiveProvider().orEmpty() },
+                    currentSourceName = getEpIndex.currentSourceName
+                        .ifBlank { extensionEngine.getActiveProviderName().orEmpty() },
                 )
                 model.updateHistory(newEp)
                 model.getWatchedHistoryEntity = null
@@ -1007,7 +1076,12 @@ class SeriesPlayerScreen : Fragment() {
                     epIndex = model.currentEpIndex,
                     isEpisode = true,
                     currentQualityIndex = model.currentSelectedVideoOptionIndex,
-                    source = PreferenceManager().getString(LocalData.SOURCE)
+                    source = PreferenceManager().getString(LocalData.SOURCE),
+                    // The real provider, so this row has an identity the phone can
+                    // match. `source` above is the routing sentinel and is the same
+                    // string for every extension.
+                    providerId = extensionEngine.getActiveProvider().orEmpty(),
+                    currentSourceName = extensionEngine.getActiveProviderName().orEmpty(),
                 )
                 model.addHistory(historyBuild)
             }
@@ -1334,5 +1408,15 @@ class SeriesPlayerScreen : Fragment() {
         if (::player.isInitialized && player.isPlaying) {
             startProgressTracking()
         }
+    }
+
+    private companion object {
+        /**
+         * How far through an episode counts as "watched" for tracking.
+         *
+         * 85% is the convention every anime tracker uses, and it exists because
+         * endings and next-episode previews are routinely skipped.
+         */
+        const val ANILIST_WATCHED_FRACTION = 0.85
     }
 }

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/search/SearchScreen.kt
@@ -117,7 +117,18 @@ class SearchScreen : Fragment() {
     private fun applyIncomingQuery() {
         val query = arguments?.getString(ARG_QUERY)?.trim().orEmpty()
         if (query.isEmpty()) return
+        val searchEverywhere = arguments?.getBoolean(ARG_SEARCH_ALL) ?: false
         arguments?.remove(ARG_QUERY)
+        arguments?.remove(ARG_SEARCH_ALL)
+
+        // "Find in sources" means SOURCES, plural. Handing the title over and
+        // then quietly searching only the active one answers a different
+        // question than the button asked — the point is finding which of the
+        // installed sources actually carries this title.
+        if (searchEverywhere && !searchAllSources) {
+            searchAllSources = true
+            binding.searchScopeToggle.text = "All sources"
+        }
 
         binding.searchEdt.setText(query)
         binding.searchEdt.setSelection(query.length)
@@ -771,6 +782,9 @@ class SearchScreen : Fragment() {
     companion object {
         /** Fragment argument carrying a pre-filled search query. */
         const val ARG_QUERY = "query"
+
+        /** Run that query across every installed source, not just the active one. */
+        const val ARG_SEARCH_ALL = "searchAll"
     }
 
 }

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/search/SearchScreen.kt
@@ -19,7 +19,10 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.saikou.sozo_tv.R
 import com.saikou.sozo_tv.adapters.SearchAdapter
 import com.saikou.sozo_tv.data.extensions.ExtensionEngine
@@ -38,6 +41,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import java.util.Locale
+import androidx.core.content.ContextCompat
+import androidx.activity.result.contract.ActivityResultContracts
+import android.Manifest
 
 class SearchScreen : Fragment() {
     private var _binding: SearchScreenBinding? = null
@@ -130,11 +136,10 @@ class SearchScreen : Fragment() {
                 if (isListening) {
                     stopVoiceRecognition()
                 } else {
-                    if (isTV) {
-                        startVoiceRecognition()
-                    } else {
-                        checkAndStartVoiceRecognition()
-                    }
+                    // TV is not exempt: the permission model is identical, and
+                    // skipping the request here is what left TV boxes with a mic
+                    // button that could only ever fail.
+                    checkAndStartVoiceRecognition()
                 }
             }
 
@@ -268,6 +273,18 @@ class SearchScreen : Fragment() {
             }
 
             override fun onPartialResults(partialResults: Bundle?) {
+                val partial = partialResults
+                    ?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+                    ?.firstOrNull()
+                    ?.takeIf { it.isNotBlank() }
+                    ?: return
+                // Feedback only — not typed into the field. Partial results are
+                // revised as the recogniser hears more, and writing them to the
+                // search box would fire a search per revision.
+                requireActivity().runOnUiThread {
+                    if (_binding == null) return@runOnUiThread
+                    binding.voiceListeningOverlay.listeningTxt.text = partial
+                }
             }
 
             override fun onEvent(eventType: Int, params: Bundle?) {
@@ -275,14 +292,40 @@ class SearchScreen : Fragment() {
         }
     }
 
+    /**
+     * Asks for the microphone, then listens.
+     *
+     * This was the hole that made voice search unusable: RECORD_AUDIO was
+     * declared in the manifest but never REQUESTED. SpeechRecognizer does not
+     * throw for a missing permission — it reports ERROR_INSUFFICIENT_PERMISSIONS
+     * through the listener, which the TV branch turned into "Microphone not
+     * available" and gave up on. Nothing anywhere asked the user, so the
+     * permission could never be granted and the feature could never work.
+     */
     private fun checkAndStartVoiceRecognition() {
-        try {
+        if (hasMicPermission()) {
             startVoiceRecognition()
-        } catch (e: SecurityException) {
-            Log.e("SearchScreen", "SecurityException: ${e.message}")
-            startAlternativeVoiceSearch()
+            return
         }
+        micPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
     }
+
+    private fun hasMicPermission(): Boolean =
+        ContextCompat.checkSelfPermission(
+            requireContext(), Manifest.permission.RECORD_AUDIO,
+        ) == PackageManager.PERMISSION_GRANTED
+
+    private val micPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            if (granted) {
+                startVoiceRecognition()
+            } else {
+                // Denied. The system recogniser activity runs in its own process
+                // with its own permission, so it still works — falling back there
+                // is better than telling the user "no".
+                startAlternativeVoiceSearch()
+            }
+        }
 
     private fun startVoiceRecognition() {
         try {
@@ -294,10 +337,21 @@ class SearchScreen : Fragment() {
                     RecognizerIntent.EXTRA_LANGUAGE_MODEL,
                     RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
                 )
-                putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault())
+                // A LANGUAGE TAG, not a Locale. `putExtra(String, Locale)` binds
+                // to the Serializable overload, compiles fine, and is then
+                // ignored by every recogniser — so speech was always transcribed
+                // in the recogniser's own default language rather than the user's.
+                putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault().toLanguageTag())
+                putExtra(
+                    RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE,
+                    Locale.getDefault().toLanguageTag(),
+                )
                 putExtra(RecognizerIntent.EXTRA_PROMPT, "Say something to search...")
                 putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
-                putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, false)
+                // On: the overlay can show words as they are recognised. Without
+                // it a TV shows a static "Listening…" and gives no sign it heard
+                // anything, which is indistinguishable from a dead microphone.
+                putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
 
                 if (isTV) {
                     putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_MINIMUM_LENGTH_MILLIS, 2000)
@@ -308,6 +362,11 @@ class SearchScreen : Fragment() {
                 }
             }
 
+            // Shown here rather than waiting for onReadyForSpeech: if the
+            // recogniser fails to start, that callback never arrives and the
+            // button looks like it did nothing at all.
+            showVoiceOverlay(true)
+            binding.voiceListeningOverlay.listeningTxt.text = "Starting…"
             speechRecognizer?.startListening(intent)
 
         } catch (e: Exception) {
@@ -326,7 +385,7 @@ class SearchScreen : Fragment() {
                     RecognizerIntent.EXTRA_LANGUAGE_MODEL,
                     RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
                 )
-                putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault())
+                putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault().toLanguageTag())
                 putExtra(RecognizerIntent.EXTRA_PROMPT, "Say something to search...")
                 putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
             }
@@ -430,13 +489,35 @@ class SearchScreen : Fragment() {
                 searchAdapter.updateData(movies)
                 binding.placeHolder.root.visibility = View.GONE
                 binding.recommendationsTitle.visibility = View.VISIBLE
-                binding.recommendationsTitle.text =
-                    getString(R.string.search_results_for, binding.searchEdt.text.toString().trim())
+                binding.recommendationsTitle.text = resultsHeading(movies.size)
+            } else if (model.loading.value) {
+                // Results now stream in one source at a time, so an empty list
+                // mid-search is normal — the first source simply had no match.
+                // Claiming "No results found" here would flash a wrong answer
+                // and then be replaced a second later.
+                hideResultsGrid()
+                binding.placeHolder.root.visibility = View.GONE
+                binding.recommendationsTitle.visibility = View.VISIBLE
+                binding.recommendationsTitle.text = resultsHeading(0)
             } else {
                 hideResultsGrid()
                 binding.placeHolder.root.visibility = View.VISIBLE
                 binding.placeHolder.placeholderTxt.text = "No results found"
                 binding.placeHolder.placeHolderImg.setImageResource(R.drawable.ic_place_holder_search)
+            }
+        }
+
+        // Progress of an "all sources" run. Kept in the heading rather than a
+        // spinner: on a TV the useful thing to know is how many sources have
+        // answered, because the user is deciding whether to keep waiting.
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                model.searchProgress.collect {
+                    if (searchAllSources && binding.recommendationsTitle.isVisible) {
+                        binding.recommendationsTitle.text =
+                            resultsHeading(model.searchResults.value?.size ?: 0)
+                    }
+                }
             }
         }
 
@@ -448,6 +529,26 @@ class SearchScreen : Fragment() {
                 binding.placeHolder.placeHolderImg.setImageResource(R.drawable.ic_network_error)
             }
         }
+    }
+
+    /**
+     * The line above the grid.
+     *
+     * In "all sources" mode it names how many sources have answered, so a search
+     * that is still running does not look like one that finished with few
+     * results — the two are indistinguishable from the grid alone.
+     */
+    private fun resultsHeading(count: Int): String {
+        val query = binding.searchEdt.text.toString().trim()
+        if (!searchAllSources) return getString(R.string.search_results_for, query)
+
+        val progress = model.searchProgress.value
+        val scope = if (model.loading.value) {
+            "${progress.answered} source(s) answered…"
+        } else {
+            "${progress.sourcesWithResults} of ${progress.answered} source(s)"
+        }
+        return "All sources — \"$query\"  •  $scope  •  $count"
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/search/SearchScreen.kt
@@ -98,6 +98,24 @@ class SearchScreen : Fragment() {
         setupSpeechRecognizer()
         binding.searchEdt.requestFocus()
         binding.seasonalBackground.setTheme(PreferenceManager().getSeasonalTheme())
+        applyIncomingQuery()
+    }
+
+    /**
+     * Runs a query handed in by another screen (AniList's "find in sources").
+     *
+     * The argument is REMOVED after use: this fragment is re-created whenever the
+     * user navigates back to search, and a lingering argument would silently
+     * re-run someone's old query instead of showing an empty search box.
+     */
+    private fun applyIncomingQuery() {
+        val query = arguments?.getString(ARG_QUERY)?.trim().orEmpty()
+        if (query.isEmpty()) return
+        arguments?.remove(ARG_QUERY)
+
+        binding.searchEdt.setText(query)
+        binding.searchEdt.setSelection(query.length)
+        performSearchImmediate(query)
     }
 
     private fun setupSpeechRecognizer() {
@@ -648,4 +666,10 @@ class SearchScreen : Fragment() {
         cancelPendingSearch()
         _binding = null
     }
+
+    companion object {
+        /** Fragment argument carrying a pre-filled search query. */
+        const val ARG_QUERY = "query"
+    }
+
 }

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/source/SourceAdapter.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/source/SourceAdapter.kt
@@ -43,6 +43,20 @@ class SourceAdapter(
     private val onProviderLongClick: (ExtProvider) -> Boolean = { false },
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
+    /**
+     * Provider ids observed to report AniList ids.
+     *
+     * A `var` fed by the screen rather than a constructor argument: the set
+     * grows as the user opens titles, and the picker should reflect that on the
+     * next visit without being rebuilt.
+     */
+    var anilistSources: Set<String> = emptySet()
+        set(value) {
+            if (field == value) return
+            field = value
+            notifyDataSetChanged()
+        }
+
     private val allItems = mutableListOf<ExtProvider>()
     private val items = mutableListOf<ExtProvider>()
     private var selectedId: String? = null
@@ -170,7 +184,9 @@ class SourceAdapter(
         return if (viewType == TYPE_HEADER) {
             HeaderVH(inflater.inflate(R.layout.header_source, parent, false))
         } else {
-            ProviderVH(inflater.inflate(R.layout.item_ext_provider, parent, false))
+            ProviderVH(
+                inflater.inflate(R.layout.item_ext_provider, parent, false),
+            ) { anilistSources }
         }
     }
 
@@ -190,7 +206,13 @@ class SourceAdapter(
         val views = SourceHeaderViews(v)
     }
 
-    class ProviderVH(v: View) : RecyclerView.ViewHolder(v) {
+    /**
+     * [anilistSources] is a lambda, not a value: holders outlive any one bind
+     * pass, and capturing the set by value would freeze whatever it happened to
+     * be when the holder was created.
+     */
+    class ProviderVH(v: View, private val anilistSources: () -> Set<String>) :
+        RecyclerView.ViewHolder(v) {
         private val icon: ImageView = v.findViewById(R.id.ivIcon)
         private val name: TextView = v.findViewById(R.id.tvName)
         private val meta: TextView = v.findViewById(R.id.tvMeta)
@@ -207,7 +229,13 @@ class SourceAdapter(
                     else -> "Local"
                 }
             } else p.group
-            meta.text = listOfNotNull(groupLabel, p.lang, p.repo)
+            // "AniList ID" marks a source that reports the AniList entry each
+            // page corresponds to. Those track EXACTLY — no title guessing, no
+            // season ambiguity. Its absence is not a claim of the opposite: a
+            // source is only known to support it once a title has been opened
+            // on it, so this reads as a confirmation, never as a verdict.
+            val anilistLabel = "AniList ID".takeIf { p.id in anilistSources() }
+            meta.text = listOfNotNull(groupLabel, p.lang, p.repo, anilistLabel)
                 .filter { it.isNotBlank() }
                 .joinToString(" · ")
             selected.isVisible = isSelected

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/source/SourceScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/source/SourceScreen.kt
@@ -28,6 +28,7 @@ import com.saikou.sozo_tv.databinding.SourceScreenBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import com.saikou.sozo_tv.data.repository.AnilistSourceRegistry
 import org.koin.android.ext.android.inject
 
 /**
@@ -48,6 +49,7 @@ class SourceScreen : Fragment() {
     private val binding get() = _binding!!
 
     private val engine: ExtensionEngine by inject()
+    private val anilistSourceRegistry: AnilistSourceRegistry by inject()
     private lateinit var adapter: SourceAdapter
 
     /** Live reference to the currently-bound header (null while it is scrolled out / recycled). */
@@ -85,6 +87,10 @@ class SourceScreen : Fragment() {
             onProviderClick = { provider -> onProviderPicked(provider) },
             onProviderLongClick = { provider -> openSettings(provider) },
         )
+
+        // Which providers have been seen reporting AniList ids. Read here rather
+        // than inside the adapter so the adapter needs no Android context.
+        adapter.anilistSources = anilistSourceRegistry.all()
 
         binding.screenRv.apply {
             layoutManager = FocusGuardLayoutManager(requireContext())

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/AnilistViewModel.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/AnilistViewModel.kt
@@ -1,0 +1,166 @@
+package com.saikou.sozo_tv.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.saikou.sozo_tv.data.remote.anilist.AnilistException
+import com.saikou.sozo_tv.data.remote.anilist.AnilistListEntry
+import com.saikou.sozo_tv.data.remote.anilist.AnilistStatus
+import com.saikou.sozo_tv.data.repository.AnilistConnection
+import com.saikou.sozo_tv.data.repository.AnilistRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Drives the AniList library screen.
+ *
+ * Holds every status in memory because AniList returns them in a single request:
+ * switching filter tabs is a local operation, and re-fetching per tab would spend
+ * a round trip to show data already held — which on a TV means a visible stall
+ * every time the d-pad moves sideways.
+ */
+class AnilistViewModel(
+    private val repository: AnilistRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(AnilistLibraryState())
+    val state: StateFlow<AnilistLibraryState> = _state.asStateFlow()
+
+    /** One-shot messages. A flow rather than state so a toast is not re-shown on rotation. */
+    private val _messages = MutableSharedFlow<String>(extraBufferCapacity = 4)
+    val messages: SharedFlow<String> = _messages.asSharedFlow()
+
+    val connection: StateFlow<AnilistConnection> = repository.connection
+
+    /**
+     * Reads the connection from the account, then loads the library.
+     *
+     * The connection is refreshed first every time rather than trusted from a
+     * previous screen: the phone can connect or disconnect at any moment, and
+     * this box has no way to be told about it.
+     */
+    fun load(force: Boolean = false) {
+        if (_state.value.loading) return
+        if (_state.value.entries.isNotEmpty() && !force) return
+
+        viewModelScope.launch {
+            _state.value = _state.value.copy(loading = true, error = null)
+            val connection = repository.refresh()
+            if (connection !is AnilistConnection.Connected) {
+                _state.value = AnilistLibraryState(loading = false)
+                return@launch
+            }
+            try {
+                val entries = repository.library()
+                _state.value = _state.value.copy(entries = entries, loading = false, error = null)
+            } catch (t: Throwable) {
+                _state.value = _state.value.copy(
+                    loading = false,
+                    error = (t as? AnilistException)?.message ?: "AniList ro'yxati yuklanmadi",
+                )
+            }
+        }
+    }
+
+    fun selectStatus(status: AnilistStatus) {
+        _state.value = _state.value.copy(status = status)
+    }
+
+    /** Marks one more episode watched. */
+    fun bumpEpisode(entry: AnilistListEntry) = setProgress(entry, entry.progress + 1)
+
+    /**
+     * Writes an explicit progress value.
+     *
+     * Optimistic: the card updates immediately and rolls back if the write fails.
+     * On a TV the round trip is long enough that an unchanged card reads as a
+     * dead button, and the remote gets pressed again.
+     */
+    fun setProgress(entry: AnilistListEntry, progress: Int) {
+        if (progress < 0 || entry.id in _state.value.busy) return
+        val previous = entry
+
+        replace(entry.copy(progress = progress), busy = _state.value.busy + entry.id)
+
+        viewModelScope.launch {
+            try {
+                val state = repository.entryState(entry.media.id)
+                val saved = repository.saveProgress(
+                    mediaId = entry.media.id,
+                    progress = progress,
+                    status = repository.statusFor(
+                        current = state?.status ?: entry.status,
+                        episode = progress,
+                        total = state?.totalEpisodes ?: entry.media.episodes,
+                    ),
+                )
+                // Trust the server's answer over the guess: AniList clamps progress
+                // to the episode total and flips status to COMPLETED on the last one.
+                replace(
+                    entry.copy(progress = saved.progress, status = saved.status),
+                    busy = _state.value.busy - entry.id,
+                )
+            } catch (t: Throwable) {
+                replace(previous, busy = _state.value.busy - entry.id)
+                _messages.tryEmit((t as? AnilistException)?.message ?: "Saqlanmadi")
+            }
+        }
+    }
+
+    /** Moves an entry to another list. */
+    fun setStatus(entry: AnilistListEntry, status: AnilistStatus) {
+        if (entry.id in _state.value.busy) return
+        val previous = entry
+        replace(entry.copy(status = status.value), busy = _state.value.busy + entry.id)
+
+        viewModelScope.launch {
+            try {
+                val saved = repository.saveProgress(
+                    mediaId = entry.media.id,
+                    progress = entry.progress,
+                    status = status.value,
+                )
+                replace(
+                    entry.copy(progress = saved.progress, status = saved.status),
+                    busy = _state.value.busy - entry.id,
+                )
+            } catch (t: Throwable) {
+                replace(previous, busy = _state.value.busy - entry.id)
+                _messages.tryEmit((t as? AnilistException)?.message ?: "Saqlanmadi")
+            }
+        }
+    }
+
+    private fun replace(updated: AnilistListEntry, busy: Set<Int>) {
+        _state.value = _state.value.copy(
+            entries = _state.value.entries.map { if (it.id == updated.id) updated else it },
+            busy = busy,
+        )
+    }
+}
+
+data class AnilistLibraryState(
+    val entries: List<AnilistListEntry> = emptyList(),
+    val status: AnilistStatus = AnilistStatus.CURRENT,
+    val loading: Boolean = false,
+    val error: String? = null,
+    /** Entry ids with a write in flight, so one slow card does not block the rest. */
+    val busy: Set<Int> = emptySet(),
+) {
+    /**
+     * The visible rows, most recently updated first — the order that puts what
+     * the viewer is actually watching at the top.
+     */
+    val visible: List<AnilistListEntry>
+        get() = entries.filter { it.status == status.value }.sortedByDescending { it.updatedAt }
+
+    val counts: Map<AnilistStatus, Int>
+        get() = entries.groupingBy { AnilistStatus.fromValue(it.status) }
+            .eachCount()
+            .mapNotNull { (status, count) -> status?.let { it to count } }
+            .toMap()
+}

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/SearchViewModel.kt
@@ -6,7 +6,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.saikou.sozo_tv.domain.model.SearchModel
 import com.saikou.sozo_tv.domain.repository.SearchRepository
+import com.saikou.sozo_tv.data.extensions.SearchLegStatus
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
@@ -45,30 +49,70 @@ class SearchViewModel(
     }
 
     /**
-     * "All sources" search. Kept separate from [searchAnime]/[searchMovie]
-     * rather than folded in behind a flag, because the screen has to be able to
-     * re-run the SAME query in the other mode — sharing `lastQuery` de-dup with
-     * them would swallow that second run as a no-op.
+     * "All sources" search.
+     *
+     * Kept separate from [searchAnime]/[searchMovie] rather than folded in
+     * behind a flag, because the screen has to be able to re-run the SAME query
+     * in the other mode — sharing `lastQuery` de-dup with them would swallow
+     * that second run as a no-op.
+     *
+     * Results are published as each source answers instead of after all of them
+     * do. The previous version awaited the whole fan-out, so one dead mirror
+     * held the screen blank for the full timeout while eight sources had already
+     * replied — which is what made this feel broken rather than slow.
      */
     fun searchAllSources(query: String) {
-        if (lastGlobalQuery == query) return
-        viewModelScope.launch {
+        val q = query.trim()
+        if (q.isEmpty()) return
+
+        // Cancelled, not skipped. The old guard returned early on a repeated
+        // query, which meant a search that came back empty because every source
+        // timed out could never be retried.
+        globalSearchJob?.cancel()
+        globalSearchJob = viewModelScope.launch {
             _loading.value = true
-            repo.searchAllSources(query)
-                .onSuccess {
-                    _loading.value = false
-                    _searchResults.value = it
-                    lastGlobalQuery = query
-                    // Let a later single-source search of the same text still run.
-                    lastQuery = ""
-                }
-                .onFailure {
-                    _loading.value = false
-                    errorData.value = it.message
-                    _searchResults.value = emptyList()
-                }
+            _searchProgress.value = SearchProgress()
+            val merged = LinkedHashMap<String, SearchModel>()
+            var answered = 0
+            var withResults = 0
+
+            try {
+                repo.searchAllSources(q)
+                    .onCompletion { _loading.value = false }
+                    .collect { leg ->
+                        answered++
+                        if (leg.status == SearchLegStatus.OK) withResults++
+                        // Deduped on the encoded content id, which already
+                        // carries provider AND url. The same title legitimately
+                        // appears on several sources and each is separately
+                        // playable, so only exact repeats collapse.
+                        for (item in leg.items) {
+                            merged.putIfAbsent("${item.id}", item)
+                        }
+                        _searchResults.value = merged.values.toList()
+                        _searchProgress.value = SearchProgress(
+                            answered = answered,
+                            sourcesWithResults = withResults,
+                            lastSource = leg.providerName,
+                        )
+                    }
+                lastGlobalQuery = q
+                // Let a later single-source search of the same text still run.
+                lastQuery = ""
+            } catch (c: CancellationException) {
+                throw c
+            } catch (t: Throwable) {
+                _loading.value = false
+                errorData.value = t.message
+            }
         }
     }
+
+    private var globalSearchJob: Job? = null
+
+    /** How far an "all sources" search has got. Drives the progress line. */
+    private val _searchProgress = MutableStateFlow(SearchProgress())
+    val searchProgress: StateFlow<SearchProgress> get() = _searchProgress
 
     private var lastGlobalQuery = ""
 
@@ -98,3 +142,10 @@ class SearchViewModel(
 
 
 }
+
+/** Progress of an in-flight "all sources" search. */
+data class SearchProgress(
+    val answered: Int = 0,
+    val sourcesWithResults: Int = 0,
+    val lastSource: String? = null,
+)

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import com.saikou.sozo_tv.data.local.pref.DeviceSession
 import com.saikou.sozo_tv.data.model.ContentMode
 import com.saikou.sozo_tv.data.model.SeasonalTheme
 import com.saikou.sozo_tv.data.model.anilist.Profile
+import com.saikou.sozo_tv.data.repository.AnilistRepository
 import com.saikou.sozo_tv.data.repository.DeviceAuthRepository
 import com.saikou.sozo_tv.data.repository.WatchHistorySyncRepository
 import com.saikou.sozo_tv.data.repository.UserListsRepository
@@ -25,6 +26,7 @@ class SettingsViewModel(
     private val deviceAuth: DeviceAuthRepository,
     private val userLists: UserListsRepository,
     private val historySync: WatchHistorySyncRepository,
+    private val anilist: AnilistRepository,
 ) : ViewModel() {
 
     val contentMode: StateFlow<ContentMode> =
@@ -71,6 +73,11 @@ class SettingsViewModel(
         // next. Both are plain local wipes, so there is nothing to await.
         userLists.clear()
         historySync.clear()
+        // The AniList token belongs to the signed-out account and writes to a
+        // real third-party list. Left behind, the next person's viewing would be
+        // filed under a stranger's AniList profile. `forgetLocal` drops this
+        // box's copy only — it does not unlink the account itself.
+        anilist.forgetLocal()
 
         // Runs on the repository's scope, not viewModelScope: the Exit dialog relaunches
         // MainActivity with CLEAR_TASK in the same handler, which tears this ViewModel down and

--- a/app/src/main/java/com/saikou/sozo_tv/utils/LocalData.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/utils/LocalData.kt
@@ -235,6 +235,10 @@ object LocalData {
         SectionItem(MyApp.context.getString(R.string.my_history), R.drawable.ic_time_history),
         SectionItem(MyApp.context.getString(R.string.bookmark), R.drawable.ic_bookmark),
         SectionItem(MyApp.context.getString(R.string.message_page), R.drawable.ic_chat),
+        // Appended, never inserted: ProfileActivity maps rail positions to
+        // destinations by INDEX, so putting this anywhere but the end would
+        // silently repoint every row after it.
+        SectionItem(MyApp.context.getString(R.string.anilist), R.drawable.ic_bookmark),
     )
     lateinit var listenerItemCategory: (isAbout: CategoryDetails) -> Unit
     fun setonClickedListenerItemCategory(listener: (isAbout: CategoryDetails) -> Unit) {

--- a/app/src/main/res/color/anilist_action_text.xml
+++ b/app/src/main/res/color/anilist_action_text.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Ordering matters: state_enabled="false" first, or a disabled button under the
+  d-pad would still paint itself white-on-blue and look pressable.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/netflix_text_secondary" android:state_enabled="false" />
+    <item android:color="@color/netflix_white" android:state_focused="true" />
+    <item android:color="@color/netflix_text_primary" />
+</selector>

--- a/app/src/main/res/color/anilist_tab_text.xml
+++ b/app/src/main/res/color/anilist_tab_text.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  White on focus (the tab is filled blue), blue when selected but not focused,
+  grey otherwise. Ordering matters: state_focused must come first, or a selected
+  tab under the cursor would keep the blue text on a blue fill.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/netflix_white" android:state_focused="true" />
+    <item android:color="@color/anilist_blue" android:state_selected="true" />
+    <item android:color="@color/netflix_text_secondary" />
+</selector>

--- a/app/src/main/res/drawable/anilist_action_bg.xml
+++ b/app/src/main/res/drawable/anilist_action_bg.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Dialog action button.
+
+  Three states, not two. A disabled button must look different from an
+  unfocused one: "Caught up" is a real answer, and drawing it like a live
+  button invites the remote to be pressed at it repeatedly.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_enabled="false">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="#14FFFFFF" />
+            <stroke
+                android:width="1dp"
+                android:color="#1FFFFFFF" />
+        </shape>
+    </item>
+
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/anilist_blue" />
+            <stroke
+                android:width="2dp"
+                android:color="@color/netflix_white" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/netflix_card_background" />
+            <stroke
+                android:width="1dp"
+                android:color="#3302A9FF" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/anilist_card_bg.xml
+++ b/app/src/main/res/drawable/anilist_card_bg.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Focus ring for an AniList poster.
+  
+  Its own drawable rather than reusing item_movie_history_bg: that one rings in
+  yellow, which on this screen would read as the app's own "continue watching"
+  accent rather than as a third-party tracker. The glow layer sits BEHIND the
+  ring so the card appears lifted rather than merely outlined — on a 10-foot
+  screen a 2dp border alone is not visible from the sofa.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_focused="true">
+        <layer-list>
+            <item>
+                <shape android:shape="rectangle">
+                    <corners android:radius="12dp" />
+                    <solid android:color="#3302A9FF" />
+                </shape>
+            </item>
+            <item
+                android:bottom="2dp"
+                android:left="2dp"
+                android:right="2dp"
+                android:top="2dp">
+                <shape android:shape="rectangle">
+                    <corners android:radius="12dp" />
+                    <stroke
+                        android:width="2dp"
+                        android:color="@color/anilist_blue" />
+                    <solid android:color="#1FFFFFFF" />
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <solid android:color="@color/netflix_background_secondary" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/anilist_chip_bg.xml
+++ b/app/src/main/res/drawable/anilist_chip_bg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="6dp" />
+    <solid android:color="#2602A9FF" />
+    <stroke
+        android:width="1dp"
+        android:color="#7302A9FF" />
+</shape>

--- a/app/src/main/res/drawable/anilist_progress.xml
+++ b/app/src/main/res/drawable/anilist_progress.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  AniList blue rather than the app's red: this bar reports what a third-party
+  tracker holds, and colouring it like a Sozo control would suggest it reflects
+  local playback progress.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:left="1dp" android:right="1dp">
+        <shape android:shape="rectangle">
+            <solid android:color="#40FFFFFF" />
+            <corners android:radius="24dp" />
+        </shape>
+    </item>
+
+    <item>
+        <clip>
+            <shape android:shape="rectangle">
+                <solid android:color="@color/anilist_blue" />
+                <corners android:radius="24dp" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/anilist_tab_bg.xml
+++ b/app/src/main/res/drawable/anilist_tab_bg.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Status tabs. Focus and selection are drawn DIFFERENTLY on purpose: on a d-pad
+  the cursor moves independently of the current filter, so a single highlight
+  would leave the user unable to tell which list they are actually looking at.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/anilist_blue" />
+        </shape>
+    </item>
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="#3302A9FF" />
+            <stroke android:width="1dp" android:color="@color/anilist_blue" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/netflix_card_background" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/anilist_entry_dialog.xml
+++ b/app/src/main/res/layout/anilist_entry_dialog.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="520dp"
+    android:layout_height="wrap_content"
+    android:background="@drawable/background_login_dialog"
+    android:orientation="vertical"
+    android:padding="22dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="72dp"
+            android:layout_height="108dp"
+            app:cardCornerRadius="8dp">
+
+            <ImageView
+                android:id="@+id/coverImage"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:contentDescription="@null"
+                android:scaleType="centerCrop" />
+        </androidx.cardview.widget.CardView>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="14dp"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/entryTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:fontFamily="@font/days"
+                android:maxLines="3"
+                android:textColor="@color/netflix_text_primary"
+                android:textSize="18sp"
+                tools:text="Frieren: Beyond Journey's End" />
+
+            <TextView
+                android:id="@+id/entryMeta"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:fontFamily="@font/rubik_regular"
+                android:textColor="@color/netflix_text_secondary"
+                android:textSize="@dimen/tv_text_label"
+                tools:text="Watching  •  8 / 28  •  3 new" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <!--
+      Primary action first in the layout so it also takes initial focus: on a
+      d-pad the first focusable is what the remote lands on, and "+1" is what
+      this dialog is opened for nine times out of ten.
+    -->
+    <TextView
+        android:id="@+id/btnBump"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:background="@drawable/anilist_tab_bg"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:fontFamily="@font/rubik_regular"
+        android:gravity="center"
+        android:paddingVertical="12dp"
+        android:textColor="@color/anilist_tab_text"
+        android:textSize="@dimen/tv_text_label"
+        android:textStyle="bold"
+        tools:text="Mark episode 9 watched" />
+
+    <TextView
+        android:id="@+id/btnSearch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/anilist_tab_bg"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:fontFamily="@font/rubik_regular"
+        android:gravity="center"
+        android:paddingVertical="12dp"
+        android:text="@string/anilist_find_in_sources"
+        android:textColor="@color/anilist_tab_text"
+        android:textSize="@dimen/tv_text_label" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:fontFamily="@font/rubik_regular"
+        android:letterSpacing="0.06"
+        android:text="@string/anilist_status"
+        android:textColor="@color/netflix_text_secondary"
+        android:textSize="@dimen/tv_text_caption"
+        android:textStyle="bold" />
+
+    <androidx.leanback.widget.HorizontalGridView
+        android:id="@+id/statusRv"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:clipChildren="false"
+        android:clipToPadding="false" />
+</LinearLayout>

--- a/app/src/main/res/layout/anilist_entry_dialog.xml
+++ b/app/src/main/res/layout/anilist_entry_dialog.xml
@@ -66,13 +66,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
-        android:background="@drawable/anilist_tab_bg"
+        android:background="@drawable/anilist_action_bg"
         android:focusable="true"
         android:focusableInTouchMode="true"
         android:fontFamily="@font/rubik_regular"
         android:gravity="center"
         android:paddingVertical="12dp"
-        android:textColor="@color/anilist_tab_text"
+        android:textColor="@color/anilist_action_text"
         android:textSize="@dimen/tv_text_label"
         android:textStyle="bold"
         tools:text="Mark episode 9 watched" />
@@ -82,14 +82,14 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:background="@drawable/anilist_tab_bg"
+        android:background="@drawable/anilist_action_bg"
         android:focusable="true"
         android:focusableInTouchMode="true"
         android:fontFamily="@font/rubik_regular"
         android:gravity="center"
         android:paddingVertical="12dp"
         android:text="@string/anilist_find_in_sources"
-        android:textColor="@color/anilist_tab_text"
+        android:textColor="@color/anilist_action_text"
         android:textSize="@dimen/tv_text_label" />
 
     <TextView

--- a/app/src/main/res/layout/anilist_screen.xml
+++ b/app/src/main/res/layout/anilist_screen.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/days"
+            android:paddingVertical="4dp"
+            android:text="@string/anilist"
+            android:textColor="@color/netflix_text_primary"
+            android:textSize="20sp" />
+
+        <TextView
+            android:id="@+id/viewerName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:fontFamily="@font/rubik_regular"
+            android:maxLines="1"
+            android:textColor="@color/anilist_blue"
+            android:textSize="@dimen/tv_text_label"
+            tools:text="azamov" />
+
+        <ProgressBar
+            android:id="@+id/loadingBar"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:indeterminateTint="@color/anilist_blue"
+            android:visibility="gone"
+            tools:visibility="visible" />
+    </LinearLayout>
+
+    <!--
+      Status filter. A HorizontalGridView rather than a plain row so the d-pad
+      scrolls it when six statuses do not fit, instead of stranding the last one
+      off-screen with no way to reach it.
+    -->
+    <androidx.leanback.widget.HorizontalGridView
+        android:id="@+id/statusRv"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:paddingHorizontal="12dp"
+        android:paddingVertical="4dp" />
+
+    <androidx.leanback.widget.VerticalGridView
+        android:id="@+id/entriesRv"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:paddingHorizontal="10dp"
+        android:paddingBottom="16dp"
+        app:focusOutEnd="true"
+        app:focusOutFront="true"
+        app:layoutManager="androidx.recyclerview.widget.GridLayoutManager" />
+
+    <!--
+      One message view for every empty state — loading, not connected, no rows,
+      network error. Separate placeholders drift apart in wording and in the
+      focus they steal.
+    -->
+    <TextView
+        android:id="@+id/messageView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fontFamily="@font/rubik_regular"
+        android:gravity="center"
+        android:lineSpacingExtra="6dp"
+        android:paddingHorizontal="48dp"
+        android:textColor="@color/netflix_text_secondary"
+        android:textSize="@dimen/tv_text_label"
+        android:visibility="gone"
+        tools:text="Connect AniList on your phone."
+        tools:visibility="visible" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_anilist_entry.xml
+++ b/app/src/main/res/layout/item_anilist_entry.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="150dp"
+    android:layout_height="wrap_content"
+    android:layout_margin="6dp"
+    android:background="@drawable/item_movie_history_bg"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:padding="8dp">
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/coverCard"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:cardCornerRadius="8dp"
+        app:layout_constraintDimensionRatio="2:3"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/coverImage"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:contentDescription="@null"
+            android:scaleType="centerCrop" />
+
+        <!--
+          Only shown when episodes have aired that the viewer has not seen. A
+          badge that is always present stops being a signal.
+        -->
+        <TextView
+            android:id="@+id/behindBadge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top|end"
+            android:layout_margin="6dp"
+            android:background="@drawable/anilist_chip_bg"
+            android:fontFamily="@font/rubik_regular"
+            android:paddingHorizontal="7dp"
+            android:paddingVertical="2dp"
+            android:textColor="@color/anilist_blue"
+            android:textSize="@dimen/tv_text_caption"
+            android:textStyle="bold"
+            android:visibility="gone"
+            tools:text="+3"
+            tools:visibility="visible" />
+
+        <androidx.core.widget.ContentLoadingProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="match_parent"
+            android:layout_height="4dp"
+            android:layout_gravity="bottom"
+            android:layout_marginHorizontal="6dp"
+            android:layout_marginBottom="6dp"
+            android:indeterminate="false"
+            android:max="100"
+            android:progressDrawable="@drawable/anilist_progress"
+            tools:progress="40" />
+    </androidx.cardview.widget.CardView>
+
+    <TextView
+        android:id="@+id/entryTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:ellipsize="end"
+        android:fontFamily="@font/rubik_regular"
+        android:maxLines="2"
+        android:minLines="2"
+        android:textColor="@color/netflix_text_primary"
+        android:textSize="@dimen/tv_text_label"
+        app:layout_constraintEnd_toEndOf="@id/coverCard"
+        app:layout_constraintStart_toStartOf="@id/coverCard"
+        app:layout_constraintTop_toBottomOf="@id/coverCard"
+        tools:text="Frieren: Beyond Journey's End" />
+
+    <TextView
+        android:id="@+id/entryProgress"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:fontFamily="@font/rubik_regular"
+        android:maxLines="1"
+        android:textColor="@color/netflix_text_secondary"
+        android:textSize="@dimen/tv_text_caption"
+        app:layout_constraintEnd_toEndOf="@id/entryTitle"
+        app:layout_constraintStart_toStartOf="@id/entryTitle"
+        app:layout_constraintTop_toBottomOf="@id/entryTitle"
+        tools:text="8 / 28" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_anilist_entry.xml
+++ b/app/src/main/res/layout/item_anilist_entry.xml
@@ -5,7 +5,7 @@
     android:layout_width="150dp"
     android:layout_height="wrap_content"
     android:layout_margin="6dp"
-    android:background="@drawable/item_movie_history_bg"
+    android:background="@drawable/anilist_card_bg"
     android:focusable="true"
     android:focusableInTouchMode="true"
     android:padding="8dp">

--- a/app/src/main/res/layout/item_anilist_status.xml
+++ b/app/src/main/res/layout/item_anilist_status.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/statusLabel"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    android:background="@drawable/anilist_tab_bg"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:fontFamily="@font/rubik_regular"
+    android:paddingHorizontal="16dp"
+    android:paddingVertical="8dp"
+    android:textColor="@color/anilist_tab_text"
+    android:textSize="@dimen/tv_text_label"
+    android:textStyle="bold"
+    tools:text="Watching  12" />

--- a/app/src/main/res/navigation/profile_graph.xml
+++ b/app/src/main/res/navigation/profile_graph.xml
@@ -36,6 +36,11 @@
         android:name="com.saikou.sozo_tv.presentation.screens.history.HistoryPage"
         android:label="HistoryPage" />
     <fragment
+        android:id="@+id/anilistScreen"
+        android:name="com.saikou.sozo_tv.presentation.screens.anilist.AnilistScreen"
+        android:label="AnilistScreen"
+        tools:layout="@layout/anilist_screen" />
+    <fragment
         android:id="@+id/newsPage"
         android:name="com.saikou.sozo_tv.presentation.screens.news.NewsPage"
         android:label="news_page"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -80,4 +80,8 @@
     <color name="notification_action_color">#FFFFFF</color>
     <color name="notification_action_bg">#404040</color>
     <color name="notification_icon_tint">#4A9EFF</color>
+    <!-- AniList's own blue. Used only for AniList affordances, so a "tracked"
+         badge is never mistaken for a Sozo-native control in red. -->
+    <color name="anilist_blue">#02A9FF</color>
+    <color name="anilist_blue_deep">#0073C4</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,4 +194,5 @@
     <string name="anilist_connect_on_phone">AniList is not connected.\n\nConnect it in the Sozo phone app under Profile → Connections. This TV picks it up automatically — no sign-in needed here.</string>
     <string name="anilist_library_empty">Your AniList list is empty.</string>
     <string name="anilist_status_empty">Nothing in “%1$s”.</string>
+    <string name="anilist_exact_tracking">AniList ID</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,4 +182,16 @@
     <string name="update_later">Later</string>
     <string name="voice_cancel_hint">Press BACK to cancel</string>
     <string name="news_empty">No messages yet</string>
+
+    <!-- AniList -->
+    <string name="anilist">AniList</string>
+    <string name="anilist_status">STATUS</string>
+    <string name="anilist_find_in_sources">Find in sources</string>
+    <string name="anilist_mark_watched">Mark episode %1$d watched</string>
+    <string name="anilist_caught_up">Caught up</string>
+    <string name="anilist_saving">Saving…</string>
+    <string name="anilist_n_new">%1$d new</string>
+    <string name="anilist_connect_on_phone">AniList is not connected.\n\nConnect it in the Sozo phone app under Profile → Connections. This TV picks it up automatically — no sign-in needed here.</string>
+    <string name="anilist_library_empty">Your AniList list is empty.</string>
+    <string name="anilist_status_empty">Nothing in “%1$s”.</string>
 </resources>

--- a/app/src/test/java/com/saikou/sozo_tv/anilist/AnilistMatchingTest.kt
+++ b/app/src/test/java/com/saikou/sozo_tv/anilist/AnilistMatchingTest.kt
@@ -1,0 +1,175 @@
+package com.saikou.sozo_tv.anilist
+
+import com.saikou.sozo_tv.data.remote.anilist.AnilistAiring
+import com.saikou.sozo_tv.data.remote.anilist.AnilistListEntry
+import com.saikou.sozo_tv.data.remote.anilist.AnilistMedia
+import com.saikou.sozo_tv.data.remote.anilist.AnilistStatus
+import com.saikou.sozo_tv.data.repository.AnilistLinkStore
+import com.saikou.sozo_tv.data.repository.AnilistTracker
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The pure decisions behind AniList tracking.
+ *
+ * Worth testing precisely because the consequences are invisible: a bad
+ * normalisation silently attaches the wrong show, and a wrong `nextEpisode`
+ * offers to mark an episode watched that has not aired. Neither produces an
+ * error — they produce a quietly wrong list.
+ *
+ * These mirror the mobile app's tests on purpose. The two clients write to one
+ * AniList account, and a rule verified on only one of them is not a rule.
+ */
+class AnilistMatchingTest {
+
+    // ─── title normalisation ────────────────────────────────────────────────
+
+    @Test
+    fun `ignores case and punctuation`() {
+        assertEquals(
+            AnilistTracker.normalizeTitle("Fate/stay night: Unlimited Blade Works"),
+            AnilistTracker.normalizeTitle("fate stay night unlimited blade works"),
+        )
+    }
+
+    @Test
+    fun `strips the release tags source sites append`() {
+        assertEquals(
+            AnilistTracker.normalizeTitle("Naruto Shippuden [1080p] (Uzbek tarjima)"),
+            AnilistTracker.normalizeTitle("Naruto Shippuden"),
+        )
+    }
+
+    @Test
+    fun `keeps non-Latin scripts intact`() {
+        // A Latin-only filter would reduce both of these to empty strings and
+        // then declare them equal — the worst possible failure for a matcher.
+        assertTrue(AnilistTracker.normalizeTitle("鋼の錬金術師").isNotEmpty())
+        assertFalse(
+            AnilistTracker.normalizeTitle("鋼の錬金術師") ==
+                AnilistTracker.normalizeTitle("進撃の巨人")
+        )
+    }
+
+    @Test
+    fun `collapses whitespace rather than leaving gaps behind`() {
+        assertEquals("one piece", AnilistTracker.normalizeTitle("  One   Piece  "))
+    }
+
+    @Test
+    fun `different seasons do not collapse into one another`() {
+        assertFalse(
+            AnilistTracker.normalizeTitle("Attack on Titan") ==
+                AnilistTracker.normalizeTitle("Attack on Titan Season 2")
+        )
+    }
+
+    // ─── link identity ──────────────────────────────────────────────────────
+
+    @Test
+    fun `link key is case-insensitive so one title is not linked twice`() {
+        assertEquals(
+            AnilistLinkStore.keyFor("cs:AnimePahe", "ABC123"),
+            AnilistLinkStore.keyFor("cs:animepahe", "abc123"),
+        )
+    }
+
+    @Test
+    fun `link key separates the same content on different providers`() {
+        // Episode numbering routinely differs between sources, so these must not
+        // share one link.
+        assertFalse(
+            AnilistLinkStore.keyFor("cs:A", "1") == AnilistLinkStore.keyFor("an:B", "1")
+        )
+    }
+
+    // ─── episode arithmetic ─────────────────────────────────────────────────
+
+    private fun entry(
+        progress: Int,
+        episodes: Int? = null,
+        airing: AnilistAiring? = null,
+    ) = AnilistListEntry(
+        id = 1,
+        media = AnilistMedia(id = 1, episodes = episodes, nextAiring = airing),
+        status = AnilistStatus.CURRENT.value,
+        progress = progress,
+    )
+
+    @Test
+    fun `offers the next episode while there are unwatched ones`() {
+        assertEquals(4, entry(progress = 3, episodes = 12).nextEpisode)
+    }
+
+    @Test
+    fun `offers nothing once the series is finished`() {
+        assertNull(entry(progress = 12, episodes = 12).nextEpisode)
+    }
+
+    @Test
+    fun `caps at what has aired, not at the announced total`() {
+        // 24 announced, episode 6 airs next => 5 exist. A viewer on 5 is caught
+        // up, and "+1" would report an episode nobody has seen.
+        val e = entry(
+            progress = 5,
+            episodes = 24,
+            airing = AnilistAiring(episode = 6, airingAt = 4_102_444_800L),
+        )
+        assertNull(e.nextEpisode)
+        assertEquals(0, e.behindBy)
+    }
+
+    @Test
+    fun `counts how far behind the viewer is on an airing show`() {
+        val e = entry(
+            progress = 2,
+            episodes = 24,
+            airing = AnilistAiring(episode = 6, airingAt = 4_102_444_800L),
+        )
+        assertEquals(3, e.behindBy)
+        assertEquals(3, e.nextEpisode)
+    }
+
+    @Test
+    fun `completion is null when the total is unknown`() {
+        assertNull(entry(progress = 4).completion)
+        assertEquals(0.5f, entry(progress = 6, episodes = 12).completion!!, 0.0001f)
+    }
+
+    // ─── airing ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `airing time is read as seconds, not milliseconds`() {
+        val airing = AnilistAiring(episode = 1, airingAt = 1_700_000_000L)
+        assertEquals(1_700_000_000_000L, airing.airsAtMillis)
+    }
+
+    @Test
+    fun `an episode in the past has aired`() {
+        assertTrue(AnilistAiring(episode = 1, airingAt = 1_000_000_000L).hasAired)
+    }
+
+    // ─── media titles ───────────────────────────────────────────────────────
+
+    @Test
+    fun `searchTitles drops blanks and duplicates, best guess first`() {
+        val media = AnilistMedia(
+            id = 1,
+            englishTitle = "Bleach",
+            romajiTitle = "Bleach",
+            nativeTitle = "ブリーチ",
+        )
+        assertEquals(listOf("Bleach", "ブリーチ"), media.searchTitles)
+    }
+
+    @Test
+    fun `displayTitle falls back when English is missing`() {
+        assertEquals(
+            "Shingeki no Kyojin",
+            AnilistMedia(id = 1, romajiTitle = "Shingeki no Kyojin").displayTitle,
+        )
+    }
+}


### PR DESCRIPTION
Depends on **sozo-backend#8** — merge that first.

Five things. The AniList feature, plus four defects found along the way.

---

## AniList

The TV never runs the OAuth handshake, and that is the design. The phone connects once, the token is stored against the Sozo account, and this box reads it from `GET /api/anilist/link`. An OAuth flow here would mean typing an AniList password with a d-pad — precisely what putting the exchange on the server exists to avoid. So the AniList screen has **no connect button at all**, only an instruction saying where to make one.

Progress is written back at **85%** of an episode rather than at the last frame: viewers skip endings and previews, and waiting for the credits loses those episodes entirely.

The same three rules as the mobile tracker govern every write — never write to an unlinked title, never move progress backwards, never surface a failure. The two clients write to **one** AniList account, and a rule enforced on only one of them is not a rule.

The title → media map is inherited from the account. That is what makes tracking here work at all: a d-pad cannot realistically search AniList, and an Uzbek or transliterated source title will never satisfy the exact-title match that is this box's only other option.

New screen under Profile: the library, filtered by status, with "+1", status changes, and "find in sources", which hands the title to the app's own search across the activity boundary.

## Provider-supplied AniList ids

Some CloudStream providers report the AniList entry a page corresponds to. That id was being discarded in the JSON bridge.

With it, tracking on those sources needs no title normalization, no season disambiguation, and carries no chance of filing episodes into the wrong show — the provider has already said which entry this is.

The list of such sources is **observed, not declared**. No manifest states which extensions support it, and a hardcoded list would be wrong the day after it was written. A provider is recorded the first time it actually reports an id, and the source picker labels it "AniList ID". The honest consequence: a source appears only after a title has been opened on it. The label is a confirmation, never a verdict on the sources that lack it.

---

## Fix: history identity the phone can match

TV rows could never line up with the phone's, for two reasons that had to be fixed together:

- `source` held the routing sentinel `"extension"` for **every** extension provider, so every row from every source shared one sync identity. A real `providerId` (`cs:`/`an:`, prefixed exactly as the phone prefixes it) is added rather than repurposing `source`, which the History filter and the player's routing both depend on.
- this box sent only a 0-based `episodeIndex` while the phone sends a 1-based `episodeNumber`, so the TV's episode 1 was keyed `e0` against the phone's `e1`. The TV already calls it "Episode ${epIndex + 1}" everywhere it shows one; it now syncs under that number.

Rows already on the server are re-keyed once and then agree; history is capped, so stale keys age out. Rows written before `providerId` existed keep their old identity rather than being given an invented one.

Schema change is a real `Migration(1, 2)`, **not** a destructive fallback: this database also holds every bookmark and saved character.

## Fix: parallel search

It awaited every provider before showing anything. One dead mirror held the screen blank for the full timeout while eight sources had already answered in under a second — which is what made it feel broken rather than slow. Legs now arrive one per source, as each answers.

Three more things were wrong with the fan-out:

- it launched all twelve providers at once. Each may download and dex-load an extension APK; on a TV box that is a thundering herd that makes every leg slower and the **first** result arrive later. Bounded to four in flight.
- the 12s per-provider budget was below what a freshly-installed source needs to fetch its extension at all, so every extension timed out on first use — exactly when the user had just added sources and was watching. Raised to 40s, paid only once per source.
- a repeated query returned early and did nothing, so a search that came back empty because everything timed out could never be retried. The previous run is now cancelled instead.

Each leg reports OK / EMPTY / TIMEOUT / ERROR rather than collapsing into an empty list: "this source is down" and "no match here" are indistinguishable otherwise, and only one is worth retrying.

## Fix: voice search

Dead on Android 11+, for a reason nothing in the code hinted at: there was no `<queries>` entry. Package visibility hides speech recognizers, so `isRecognitionAvailable()` returns false **and** `resolveActivity()` returns null even with Google's recognizer installed and working. Both paths fell through to "Voice search not available".

Underneath that, three more:

- `RECORD_AUDIO` was declared but never **requested**. `SpeechRecognizer` does not throw for a missing permission — it reports `ERROR_INSUFFICIENT_PERMISSIONS`, which the TV branch turned into "Microphone not available" and gave up on. Nothing asked the user, so it could never be granted. The TV path skipped the check entirely, which is why boxes fared worst.
- `EXTRA_LANGUAGE` was passed a `Locale` object. That binds to the `Serializable` overload, compiles, and is ignored by every recognizer — so speech was always transcribed in the recognizer's default language, not the user's.
- `android.hardware.microphone` was `required="true"`, which makes the app **uninstallable** on the many TV boxes whose mic lives in the remote or does not exist.

Partial results are on, so the overlay shows words as they are heard instead of a static "Listening…" indistinguishable from a dead microphone.

## Fix: D-pad focus

The AniList screens now use the helpers this codebase already has, which they were not:

- `keepFocusAlive` around the grid's visibility swaps and `submitList`. Android does not reassign focus when the focused view is hidden or its row removed — it clears focus to the root and the remote goes dead.
- `applyTvFocusScale` moved from `bind()` to holder init: re-registering the listener on a recycled view that currently holds focus makes the highlight jump.
- disabling the dialog's primary button hands focus to the next action. A disabled view is not focusable, so disabling the one under the cursor stranded the remote.
- dedicated focus drawables rather than borrowing the history card's yellow ring, including a distinct disabled state — "Caught up" is a real answer and should not look like a button worth pressing harder.

---

## Tests

16 new unit tests covering normalization, link identity and the aired-episode cap. These are the app's first — `junit` was not previously a dependency. `assembleDebug` and `testDebugUnitTest` both pass.

## Noted, not changed

`adapters/SourceAdapter.kt` is dead code. `SourceScreen` uses the identically-named class in `presentation/screens/source/`, and nothing references the other. Left in place rather than deleted as part of an unrelated change.

## Not verified

The APK builds but has not been installed or run. No OAuth round trip, no live AniList request, and no d-pad testing on real hardware. The behaviour is correct by reading, not by observation.