### PR TITLE
Let the release push survive branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ name: Release → Telegram
 #   ANDROID_TV_KEY_PROPERTIES contents of key.properties — storeFile,
 #                             storePassword, keyAlias, keyPassword
 #   TELEGRAM_BOT_TOKEN        bot token from @BotFather
+#   RELEASE_PAT               fine-grained PAT with Contents: read and write.
+#                             Required because the default branch blocks direct
+#                             pushes and GITHUB_TOKEN is not an admin.
 #   TELEGRAM_CHAT_IDS         comma-separated NUMERIC chat ids. The Bot API
 #                             cannot message a person by @username; each
 #                             recipient must press Start on the bot once.
@@ -62,6 +65,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # RELEASE_PAT is an admin token. The default GITHUB_TOKEN is not an
+          # admin, so the version-bump push below is rejected by the branch
+          # ruleset that blocks direct pushes to the default branch.
+          token: ${{ secrets.RELEASE_PAT || github.token }}
 
       - name: Resolve version
         id: resolve
@@ -158,7 +165,11 @@ jobs:
           git commit -am "chore: ${NAME} (${CODE})"
           git tag "${TAG}"
 
-          git push origin HEAD:"${GITHUB_REF_NAME}"
+          if ! git push origin HEAD:"${GITHUB_REF_NAME}"; then
+            echo "::error title=Push rejected::The default branch is protected and this run is not an admin. Add a RELEASE_PAT secret (a fine-grained PAT with Contents: read and write) so the version bump can land. Nothing was tagged."
+            git tag -d "${TAG}"
+            exit 1
+          fi
           git push origin "${TAG}"
 
       - name: Record the commit the build job will use


### PR DESCRIPTION
The default branch now blocks direct pushes (ruleset "Protect Default", `update` rule). `GITHUB_TOKEN` is not an admin, so the version-bump commit this workflow makes would be **rejected** — and it would fail *after* the version had been decided, leaving a tag pointing at a commit that never landed on `master`.

Checkout now authenticates with `RELEASE_PAT` when it exists, falling back to the default token so nothing breaks before you add the secret.

If the push is rejected anyway, the local tag is deleted and the run fails with the reason and the fix, rather than half-completing.

## You need to add one secret

`RELEASE_PAT` — a fine-grained PAT with **Contents: read and write** on this repo. Because you are the only admin, a token of yours bypasses the ruleset.

Without it, `bump: none` still works (nothing is pushed); every other bump mode fails with a clear message.