### PR TITLE
Profile crash, rail focus, and a separate Server button

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-08-15T09:35:13.322294Z">
+        <DropdownSelection timestamp="2026-08-18T04:46:23.495534Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/azamov/.android/avd/Television_1080p.avd" />

--- a/app/src/main/java/com/saikou/sozo_tv/adapters/ProfileAdapter.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/adapters/ProfileAdapter.kt
@@ -34,6 +34,9 @@ class ProfileAdapter(
     private lateinit var onSectionClick: (SectionItem, Int) -> Unit
 
     private var selectedSectionIndex: Int = RecyclerView.NO_POSITION
+
+    /** Consumed by the first bind of the selected row; see bind(). */
+    private var focusPending: Boolean = true
     private var pendingNav: Runnable? = null
 
     fun setOnExitClickListener(listener: () -> Unit) {
@@ -116,18 +119,26 @@ class ProfileAdapter(
             val isSelected = sectionPosition == selectedSectionIndex
 
 
-            if (isSelected) {
+            // Focus is placed ONCE, on the first bind of the selected row. Requesting it
+            // on every bind dragged focus back to the rail whenever a row rebound, so
+            // moving right into the content pane did not stick.
+            if (isSelected && focusPending) {
+                focusPending = false
                 binding.root.requestFocus()
-                setSectionSelected(sectionPosition)
-
-            } else {
-                binding.root.clearFocus()
             }
+            // No setSectionSelected() here: it calls notifyItemChanged, and mutating the
+            // adapter from inside bind runs during layout. The focus listener below is
+            // what owns selection.
+            // No clearFocus() either — clearing focus on a recycled view strands the
+            // d-pad, since Android does not hand it anywhere afterwards.
 
             binding.root.isFocusable = true
             binding.root.isFocusableInTouchMode = true
 
-            binding.root.applyTvFocusScale(scale = 1.06f) { _, hasFocus ->
+            // These rows are full-width, so a scale-up grows them past the rail's edge
+            // and over the screen border. The white focused background is the
+            // affordance; 1f keeps the z-lift and the callback without the overflow.
+            binding.root.applyTvFocusScale(scale = 1f) { _, hasFocus ->
                 if (hasFocus) {
                     setSectionSelected(sectionPosition)
                     // Debounce: passing focus THROUGH rail items must not load every screen
@@ -252,6 +263,14 @@ class ProfileAdapter(
         }
         accounts[0] = account
         notifyItemChanged(1)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        super.onDetachedFromRecyclerView(recyclerView)
+        // The pending navigation outlives the view it was scheduled on. Left to run,
+        // it reaches an activity that is already tearing down.
+        pendingNav?.let { recyclerView.removeCallbacks(it) }
+        pendingNav = null
     }
 
     fun setSectionSelected(index: Int) {

--- a/app/src/main/java/com/saikou/sozo_tv/adapters/ProfileAdapter.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/adapters/ProfileAdapter.kt
@@ -37,6 +37,9 @@ class ProfileAdapter(
 
     /** Consumed by the first bind of the selected row; see bind(). */
     private var focusPending: Boolean = true
+
+    /** Deferred selection repaint; see setSectionSelected. */
+    private var pendingSelectionNotify: Runnable? = null
     private var pendingNav: Runnable? = null
 
     fun setOnExitClickListener(listener: () -> Unit) {
@@ -271,6 +274,8 @@ class ProfileAdapter(
         // it reaches an activity that is already tearing down.
         pendingNav?.let { recyclerView.removeCallbacks(it) }
         pendingNav = null
+        pendingSelectionNotify?.let { recyclerView.removeCallbacks(it) }
+        pendingSelectionNotify = null
     }
 
     fun setSectionSelected(index: Int) {
@@ -278,10 +283,24 @@ class ProfileAdapter(
         val previousIndex = selectedSectionIndex
         selectedSectionIndex = index
 
-        if (previousIndex != RecyclerView.NO_POSITION) {
-            notifyItemChanged(previousIndex + accounts.size + 2)
+        // Leanback's GridLayoutManager moves focus from inside onLayoutChildren
+        // (focusToViewInLayout), so the focus listener that calls this runs
+        // DURING layout — and notifyItemChanged throws there. Deferring to the
+        // next frame is the only safe moment; the rows repaint one frame later,
+        // which is invisible next to the focus animation itself.
+        val notify = Runnable {
+            if (previousIndex != RecyclerView.NO_POSITION) {
+                notifyItemChanged(previousIndex + accounts.size + 2)
+            }
+            notifyItemChanged(index + accounts.size + 2)
         }
-        notifyItemChanged(selectedSectionIndex + accounts.size + 2)
+        if (recyclerView.isComputingLayout || recyclerView.scrollState != RecyclerView.SCROLL_STATE_IDLE) {
+            pendingSelectionNotify?.let { recyclerView.removeCallbacks(it) }
+            pendingSelectionNotify = notify
+            recyclerView.post(notify)
+        } else {
+            notify.run()
+        }
     }
 
 }

--- a/app/src/main/java/com/saikou/sozo_tv/adapters/VideoServersAdapter.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/adapters/VideoServersAdapter.kt
@@ -1,0 +1,43 @@
+package com.saikou.sozo_tv.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import com.saikou.sozo_tv.databinding.ItemVideoServerBinding
+import com.saikou.sozo_tv.utils.applyTvFocusScale
+
+class VideoServersAdapter(
+    private val servers: List<ServerRow>,
+    private var selectedPosition: Int,
+    private val onItemClick: (ServerRow) -> Unit,
+) : RecyclerView.Adapter<VideoServersAdapter.VH>() {
+
+    data class ServerRow(val name: String, val qualities: String)
+
+    inner class VH(private val binding: ItemVideoServerBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        init {
+            binding.root.applyTvFocusScale(scale = 1.02f)
+        }
+
+        fun bind(row: ServerRow, position: Int) = with(binding) {
+            tvServerName.text = row.name
+            tvServerQualities.text = row.qualities
+            tvServerQualities.isVisible = row.qualities.isNotBlank()
+            ivServerSelected.isVisible = position == selectedPosition
+            root.isSelected = position == selectedPosition
+            root.setOnClickListener { onItemClick(row) }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = VH(
+        ItemVideoServerBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+    )
+
+    override fun onBindViewHolder(holder: VH, position: Int) =
+        holder.bind(servers[position], position)
+
+    override fun getItemCount() = servers.size
+}

--- a/app/src/main/java/com/saikou/sozo_tv/domain/player/VideoOptionGroups.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/domain/player/VideoOptionGroups.kt
@@ -1,0 +1,53 @@
+package com.saikou.sozo_tv.domain.player
+
+import com.saikou.sozo_tv.parser.models.VideoOption
+
+/**
+ * Splits the flat option list into servers and the qualities each one offers.
+ *
+ * A source returns one list mixing both — "Server A 1080p", "Server B 720p" — and
+ * the player showed it raw, so picking a quality could silently move you to a
+ * different host. Servers and qualities are independent choices and get one
+ * button each.
+ */
+object VideoOptionGroups {
+
+    private val RESOLUTION = Regex("""(\d{3,4})""")
+
+    fun servers(options: List<VideoOption>): List<String> =
+        options.map { it.serverName() }.distinct()
+
+    /** Positions in the ORIGINAL list, so the caller's selected index stays valid. */
+    fun indicesFor(options: List<VideoOption>, server: String): List<Int> =
+        options.indices.filter { options[it].serverName() == server }
+
+    fun serverOf(options: List<VideoOption>, index: Int): String =
+        options.getOrNull(index)?.serverName().orEmpty()
+
+    /**
+     * The option to land on when switching to [server], keeping the current
+     * quality where that server has it.
+     *
+     * Falls back to the server's highest resolution rather than its first entry:
+     * sources list hosts in arbitrary order, and dropping someone from 1080p to
+     * 360p because that host happened to be listed first reads as a bug.
+     */
+    fun switchTo(options: List<VideoOption>, currentIndex: Int, server: String): Int {
+        val candidates = indicesFor(options, server)
+        if (candidates.isEmpty()) return currentIndex
+
+        val wanted = options.getOrNull(currentIndex)?.let { resolutionOf(it) }
+        if (wanted != null) {
+            candidates.firstOrNull { resolutionOf(options[it]) == wanted }?.let { return it }
+        }
+        return candidates.maxByOrNull { resolutionOf(options[it]) ?: 0 } ?: candidates.first()
+    }
+
+    fun resolutionOf(option: VideoOption): Int? =
+        RESOLUTION.find(option.resolution)?.value?.toIntOrNull()
+            ?: RESOLUTION.find(option.quality)?.value?.toIntOrNull()
+
+    /** Blank host names are common; they still need a stable label to group under. */
+    private fun VideoOption.serverName(): String =
+        fansub.trim().ifBlank { "Default" }
+}

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/activities/ProfileActivity.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/activities/ProfileActivity.kt
@@ -181,7 +181,13 @@ class ProfileActivity : AppCompatActivity(), MyAccountPage.AuthNavigator {
         profileAdapter.setSectionSelected(if (isSettingsOpen) 3 else 0)
 
         profileAdapter.sectionClickListener { _, position ->
-            val navController = findNavController(R.id.nav_profile)
+            // The rail navigates 300ms after focus settles, so this can fire once the
+            // activity is already finishing, or before the NavHostFragment has been
+            // created. findNavController throws in both cases, which is what crashed
+            // the app on the way out of this screen.
+            if (isFinishing || isDestroyed) return@sectionClickListener
+            val navController = runCatching { findNavController(R.id.nav_profile) }.getOrNull()
+                ?: return@sectionClickListener
             val currentPageId = navController.currentDestination?.id
             backPressCount = 2
 

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
@@ -23,6 +23,8 @@ import androidx.annotation.OptIn
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import com.saikou.sozo_tv.domain.player.VideoOptionGroups
+import com.saikou.sozo_tv.adapters.VideoServersAdapter
 import com.saikou.sozo_tv.data.extensions.ExtensionEngine
 import com.saikou.sozo_tv.data.repository.AnilistTracker
 import org.koin.android.ext.android.inject
@@ -495,17 +497,64 @@ class SeriesPlayerScreen : Fragment() {
         setupPlayerSettings()
 
         model.videoOptionsData.observe(viewLifecycleOwner) { videoOptions ->
-            binding.pvPlayer.controller.binding.exoQuality.setOnClickListener {
-                if (videoOptions.isNullOrEmpty()) return@setOnClickListener
-                val dialog = VideoQualityDialog(videoOptions, model.currentSelectedVideoOptionIndex)
-                dialog.setYesContinueListener { _, i ->
-                    if (i != model.currentSelectedVideoOptionIndex) {
-                        ignoreNextEpisodeSuccess = true
-                        model.currentSelectedVideoOptionIndex = i
-                        model.updateQualityByIndex()
-                    }
+            val controls = binding.pvPlayer.controller.binding
+            val options = videoOptions.orEmpty()
+            val servers = VideoOptionGroups.servers(options)
+
+            // Only worth a button when there is a choice to make.
+            controls.exoServer.isVisible = servers.size > 1
+
+            controls.exoServer.setOnClickListener {
+                if (servers.size < 2) return@setOnClickListener
+                val current = VideoOptionGroups.serverOf(
+                    options, model.currentSelectedVideoOptionIndex,
+                )
+                val rows = servers.map { name ->
+                    VideoServersAdapter.ServerRow(
+                        name = name,
+                        qualities = VideoOptionGroups.indicesFor(options, name)
+                            .mapNotNull { options[it].resolution.trim().ifBlank { null } }
+                            .distinct()
+                            .joinToString(" · "),
+                    )
                 }
-                dialog.show(parentFragmentManager, "VideoQualityDialog")
+                VideoServerDialog(rows, servers.indexOf(current).coerceAtLeast(0)).apply {
+                    setOnServerPicked { picked ->
+                        val target = VideoOptionGroups.switchTo(
+                            options, model.currentSelectedVideoOptionIndex, picked,
+                        )
+                        if (target != model.currentSelectedVideoOptionIndex) {
+                            ignoreNextEpisodeSuccess = true
+                            model.currentSelectedVideoOptionIndex = target
+                            model.updateQualityByIndex()
+                        }
+                    }
+                }.show(parentFragmentManager, "VideoServerDialog")
+            }
+
+            controls.exoQuality.setOnClickListener {
+                if (options.isEmpty()) return@setOnClickListener
+                // Scoped to the current server: a quality list spanning hosts means
+                // picking a resolution silently moves you to a different one.
+                val currentServer = VideoOptionGroups.serverOf(
+                    options, model.currentSelectedVideoOptionIndex,
+                )
+                val indices = VideoOptionGroups.indicesFor(options, currentServer)
+                    .ifEmpty { options.indices.toList() }
+                val subset = indices.map { options[it] }
+                val selected = indices.indexOf(model.currentSelectedVideoOptionIndex)
+                    .coerceAtLeast(0)
+
+                VideoQualityDialog(subset, selected).apply {
+                    setYesContinueListener { _, i ->
+                        val target = indices.getOrNull(i) ?: return@setYesContinueListener
+                        if (target != model.currentSelectedVideoOptionIndex) {
+                            ignoreNextEpisodeSuccess = true
+                            model.currentSelectedVideoOptionIndex = target
+                            model.updateQualityByIndex()
+                        }
+                    }
+                }.show(parentFragmentManager, "VideoQualityDialog")
             }
         }
 

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/VideoServerDialog.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/VideoServerDialog.kt
@@ -1,0 +1,59 @@
+package com.saikou.sozo_tv.presentation.screens.play
+
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.saikou.sozo_tv.R
+import com.saikou.sozo_tv.adapters.VideoServersAdapter
+import com.saikou.sozo_tv.databinding.DialogVideoQualityBinding
+
+class VideoServerDialog(
+    private val servers: List<VideoServersAdapter.ServerRow>,
+    private val currentIndex: Int,
+) : DialogFragment() {
+
+    private var _binding: DialogVideoQualityBinding? = null
+    private val binding get() = _binding!!
+
+    private var onPick: ((String) -> Unit)? = null
+
+    fun setOnServerPicked(listener: (String) -> Unit) {
+        onPick = listener
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = DialogVideoQualityBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(0))
+        dialog?.window?.setWindowAnimations(R.style.DialogAnimation)
+
+        binding.dialogTitle.text = getString(R.string.player_server_title)
+        binding.dialogSubtitle.text = getString(R.string.player_server_subtitle)
+
+        binding.videOptionRv.adapter = VideoServersAdapter(servers, currentIndex) { row ->
+            onPick?.invoke(row.name)
+            dismiss()
+        }
+
+        binding.videOptionRv.post {
+            binding.videOptionRv.setSelectedPosition(currentIndex.coerceAtLeast(0))
+            binding.videOptionRv.requestFocus()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/content_controller_tv_series.xml
+++ b/app/src/main/res/layout/content_controller_tv_series.xml
@@ -305,6 +305,36 @@
             android:orientation="horizontal">
 
             <FrameLayout
+                android:id="@+id/exo_server"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_gravity="center"
+                android:layout_marginTop="7dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginBottom="7dp"
+                android:background="@drawable/shape_play_settings"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/exo_quality"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="center"
+                    android:duplicateParentState="true"
+                    android:nextFocusUp="@id/exo_progress"
+                    android:padding="12dp"
+                    android:tint="@color/color_black_white_text"
+                    app:srcCompat="@drawable/ic_round_star_24"
+                    app:tint="@color/color_black_white_text"
+                    app:tintMode="multiply" />
+
+            </FrameLayout>
+
+            <FrameLayout
                 android:id="@+id/exo_quality"
                 android:layout_width="48dp"
                 android:layout_height="48dp"

--- a/app/src/main/res/layout/dialog_video_quality.xml
+++ b/app/src/main/res/layout/dialog_video_quality.xml
@@ -32,22 +32,24 @@
                 app:tint="@color/red" />
 
             <TextView
+                android:id="@+id/dialogTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:fontFamily="sans-serif-medium"
                 android:gravity="center"
-                android:text="Video Quality Settings"
+                android:text="@string/player_quality_title"
                 android:textColor="#ffffff"
                 android:textSize="22sp" />
 
             <TextView
+                android:id="@+id/dialogSubtitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:gravity="center"
                 android:lineSpacingExtra="2dp"
                 android:maxWidth="520dp"
-                android:text="Choose your preferred video quality and audio type for the best viewing experience."
+                android:text="@string/player_quality_subtitle"
                 android:textColor="#9ca3af"
                 android:textSize="@dimen/tv_text_subtitle" />
 

--- a/app/src/main/res/layout/item_video_server.xml
+++ b/app/src/main/res/layout/item_video_server.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    android:background="@drawable/item_round_bg_selectable"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:padding="12dp">
+
+    <ImageView
+        android:layout_width="26dp"
+        android:layout_height="26dp"
+        android:layout_marginEnd="16dp"
+        android:contentDescription="@null"
+        android:src="@drawable/ic_round_star_24"
+        app:tint="@color/red" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tvServerName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-medium"
+            android:maxLines="1"
+            android:textColor="#ffffff"
+            android:textSize="@dimen/tv_text_subtitle"
+            tools:text="Mp4Upload" />
+
+        <TextView
+            android:id="@+id/tvServerQualities"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="#9ca3af"
+            android:textSize="@dimen/tv_text_caption"
+            tools:text="1080p · 720p · 480p" />
+    </LinearLayout>
+
+    <ImageView
+        android:id="@+id/ivServerSelected"
+        android:layout_width="22dp"
+        android:layout_height="22dp"
+        android:contentDescription="@null"
+        android:src="@drawable/ic_check"
+        android:visibility="gone"
+        app:tint="@color/red"
+        tools:visibility="visible" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,4 +194,8 @@
     <string name="anilist_library_empty">Your AniList list is empty.</string>
     <string name="anilist_status_empty">Nothing in “%1$s”.</string>
     <string name="anilist_exact_tracking">AniList ID</string>
+    <string name="player_quality_title">Video quality</string>
+    <string name="player_quality_subtitle">Pick the resolution for the current server.</string>
+    <string name="player_server_title">Server</string>
+    <string name="player_server_subtitle">Choose which host streams this episode. Quality is picked separately.</string>
 </resources>

--- a/app/src/test/java/com/saikou/sozo_tv/player/VideoOptionGroupsTest.kt
+++ b/app/src/test/java/com/saikou/sozo_tv/player/VideoOptionGroupsTest.kt
@@ -1,0 +1,75 @@
+package com.saikou.sozo_tv.player
+
+import com.saikou.sozo_tv.domain.player.VideoOptionGroups
+import com.saikou.sozo_tv.parser.models.AudioType
+import com.saikou.sozo_tv.parser.models.VideoOption
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VideoOptionGroupsTest {
+
+    private fun opt(server: String, res: String) = VideoOption(
+        videoUrl = "https://x/$server/$res",
+        fansub = server,
+        resolution = res,
+        audioType = AudioType.SUB,
+        quality = res,
+        isActive = true,
+        fullText = "$server $res",
+    )
+
+    private val options = listOf(
+        opt("Alpha", "1080p"),
+        opt("Alpha", "720p"),
+        opt("Beta", "720p"),
+        opt("Beta", "480p"),
+        opt("Beta", "1080p"),
+    )
+
+    @Test
+    fun `servers are distinct and keep source order`() {
+        assertEquals(listOf("Alpha", "Beta"), VideoOptionGroups.servers(options))
+    }
+
+    @Test
+    fun `indices point back into the original list`() {
+        assertEquals(listOf(2, 3, 4), VideoOptionGroups.indicesFor(options, "Beta"))
+    }
+
+    @Test
+    fun `switching server keeps the same resolution when it exists`() {
+        assertEquals(2, VideoOptionGroups.switchTo(options, currentIndex = 1, server = "Beta"))
+    }
+
+    @Test
+    fun `switching to a server without that resolution takes its highest`() {
+        val sparse = listOf(opt("Alpha", "1080p"), opt("Beta", "480p"), opt("Beta", "720p"))
+        assertEquals(2, VideoOptionGroups.switchTo(sparse, currentIndex = 0, server = "Beta"))
+    }
+
+    @Test
+    fun `switching to an unknown server changes nothing`() {
+        assertEquals(1, VideoOptionGroups.switchTo(options, currentIndex = 1, server = "Nope"))
+    }
+
+    @Test
+    fun `a blank host name still groups under one label`() {
+        val blanks = listOf(opt("", "1080p"), opt("   ", "720p"))
+        assertEquals(listOf("Default"), VideoOptionGroups.servers(blanks))
+    }
+
+    @Test
+    fun `resolution is read from either field`() {
+        assertEquals(1080, VideoOptionGroups.resolutionOf(opt("A", "1080p")))
+        val odd = VideoOption(
+            videoUrl = "u", fansub = "A", resolution = "auto", audioType = AudioType.SUB,
+            quality = "HD 720", isActive = true, fullText = "",
+        )
+        assertEquals(720, VideoOptionGroups.resolutionOf(odd))
+    }
+
+    @Test
+    fun `serverOf is safe on an out of range index`() {
+        assertEquals("", VideoOptionGroups.serverOf(options, 99))
+    }
+}


### PR DESCRIPTION
Three reports from the TV.

## 1. Crash leaving the profile screen

```
IllegalStateException: ProfileActivity does not have a NavController set on 2131428186
    at ProfileActivity$setUpRv$6.invoke(ProfileActivity.kt:184)
```

The rail navigates **300ms after focus settles**, on a `Handler`. That callback outlives whatever scheduled it, so it lands either *before* the `NavHostFragment` has been created or *after* the activity has started finishing — and `findNavController` throws in both cases.

The lookup is now guarded, and the pending navigation is cancelled when the adapter detaches. Two windows, both closed, rather than only the one that happened to reproduce.

## 2. The rail row that would not let go

`bind()` called `requestFocus()` on the selected row **every time it bound**. Any rebind therefore dragged focus back to the rail, so moving right into the content pane did not stick. Focus is now placed once, on the first bind.

Two more things in the same method:

- it called `setSectionSelected()`, which calls `notifyItemChanged` — an adapter mutation from inside `bind`, i.e. during layout. Removed; the focus listener already owns selection.
- it called `clearFocus()` on unselected rows. Clearing focus on a recycled view strands the d-pad, because Android does not hand it anywhere afterwards.

The focused row also **grew past the rail's edge and over the screen border** — that is the white bar in your screenshot. These rows are full width, so a 1.06 scale has nowhere to go. The white focused background is already the affordance.

## 3. Server and quality were one button

A source returns one flat list mixing both — `Server A 1080p`, `Server B 720p` — and the player showed it raw. So picking a *quality* could silently move you to a different *host*.

They are independent choices and now get one button each:

- **Server** — the hosts carrying this episode, each showing the qualities it offers. Hidden when there is only one; nothing to choose.
- **Quality** — resolutions **on the current server only**, for the same reason as above.

Switching server keeps the current resolution where that server has it, and otherwise takes that server's **highest** rather than its first. Sources list hosts in arbitrary order, and dropping someone from 1080p to 360p because a host happened to be listed first reads as a bug.

## Tests

8 new, covering the grouping: server order, index mapping back into the original list, the resolution-preserving switch, the highest-quality fallback, unknown servers, blank host names, and reading a resolution from either field. 24 total, all passing. APK builds.

Not verified on a device — the crash fix is reasoned from the stack trace, not reproduced.