### PR TITLE
AniList tabs, logo, dialog panel, and a bigger search keyboard

### DIFF
--- a/app/src/main/java/com/saikou/sozo_tv/adapters/ProfileAdapter.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/adapters/ProfileAdapter.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AnimationUtils
 import androidx.core.widget.ImageViewCompat
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.saikou.sozo_tv.R
 import com.saikou.sozo_tv.data.model.SectionItem
@@ -117,6 +118,13 @@ class ProfileAdapter(
         fun bind(section: SectionItem) {
             binding.sectionTxt.text = section.sectionTitle
             binding.sectionImg.setImageResource(section.sectionImg)
+            // The rail tints icons to follow focus. A brand badge must keep its
+            // own colours, so it opts out.
+            binding.sectionImg.imageTintList =
+                if (section.sectionImg == R.drawable.ic_anilist_badge) null
+                else ContextCompat.getColorStateList(
+                    binding.root.context, R.color.color_item_tv_section_profile,
+                )
 
             val sectionPosition = sectionList.indexOf(section)
             val isSelected = sectionPosition == selectedSectionIndex

--- a/app/src/main/java/com/saikou/sozo_tv/adapters/SearchAdapter.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/adapters/SearchAdapter.kt
@@ -11,6 +11,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.RequestOptions
+import androidx.core.view.isVisible
+import com.saikou.sozo_tv.data.extensions.ExtensionContentRegistry
 import com.saikou.sozo_tv.databinding.SearchItemBinding
 import com.saikou.sozo_tv.domain.model.SearchModel
 
@@ -18,6 +20,14 @@ class SearchAdapter :
     RecyclerView.Adapter<SearchAdapter.MovieViewHolder>() {
     private var movieList = ArrayList<SearchModel>()
     var query: String = ""
+
+    /** Only meaningful when results span providers; a single-source search knows. */
+    var showSource: Boolean = false
+        set(value) {
+            if (field == value) return
+            field = value
+            notifyItemRangeChanged(0, movieList.size)
+        }
 
     private lateinit var itemClickeddListener: (movie: SearchModel) -> Unit
     fun setOnItemClickListener(listener: (movie: SearchModel) -> Unit) {
@@ -33,6 +43,17 @@ class SearchAdapter :
         RecyclerView.ViewHolder(binding.root) {
         @SuppressLint("SetTextI18n", "NewApi")
         fun bind(movie: SearchModel) {
+            // Which source found this. In an all-sources search the same title
+            // comes back from several, and without this the duplicates look
+            // like a bug rather than a choice of where to play from.
+            val source = movie.id
+                ?.let { ExtensionContentRegistry.resolve(it) }
+                ?.provider
+                ?.substringAfter(':')
+                ?.takeIf { it.isNotBlank() }
+            binding.movieSource.isVisible = showSource && source != null
+            binding.movieSource.text = source.orEmpty()
+
             binding.root.setOnClickListener {
                 itemClickeddListener.invoke(movie)
             }

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/search/SearchScreen.kt
@@ -575,6 +575,7 @@ class SearchScreen : Fragment() {
             val q = query.trim()
             // Active provider by default; "All sources" fans out across every
             // installed one (bounded + failure-tolerant in ExtensionEngine).
+            searchAdapter.showSource = searchAllSources
             if (searchAllSources) model.searchAllSources(q) else model.searchAnime(q)
             searchAdapter.setQueryText(q)
             binding.recommendationsTitle.visibility = View.VISIBLE

--- a/app/src/main/java/com/saikou/sozo_tv/utils/LocalData.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/utils/LocalData.kt
@@ -233,7 +233,7 @@ object LocalData {
         SectionItem(MyApp.context.getString(R.string.my_history), R.drawable.ic_time_history),
         SectionItem(MyApp.context.getString(R.string.bookmark), R.drawable.ic_bookmark),
         SectionItem(MyApp.context.getString(R.string.message_page), R.drawable.ic_chat),
-        SectionItem(MyApp.context.getString(R.string.anilist), R.drawable.ic_bookmark),
+        SectionItem(MyApp.context.getString(R.string.anilist), R.drawable.ic_anilist_badge),
     )
     lateinit var listenerItemCategory: (isAbout: CategoryDetails) -> Unit
     fun setonClickedListenerItemCategory(listener: (isAbout: CategoryDetails) -> Unit) {

--- a/app/src/main/res/color/anilist_tab_text.xml
+++ b/app/src/main/res/color/anilist_tab_text.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/netflix_white" android:state_selected="true" />
     <item android:color="@color/netflix_white" android:state_focused="true" />
-    <item android:color="@color/anilist_blue" android:state_selected="true" />
     <item android:color="@color/netflix_text_secondary" />
 </selector>

--- a/app/src/main/res/drawable/anilist_dialog_bg.xml
+++ b/app/src/main/res/drawable/anilist_dialog_bg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Opaque. The shared login-dialog background is #4D000000, which over a dark
+  screen is barely a tint — the entry sheet appeared to have no panel at all and
+  its buttons floated over the grid behind them.
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="18dp" />
+    <solid android:color="@color/netflix_dark_gray" />
+    <stroke
+        android:width="1dp"
+        android:color="#26FFFFFF" />
+</shape>

--- a/app/src/main/res/drawable/anilist_tab_bg.xml
+++ b/app/src/main/res/drawable/anilist_tab_bg.xml
@@ -1,18 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Selection is the filter you are looking at; focus is where the d-pad happens
+  to be. Painting both blue made two tabs read as active at once, so selection
+  owns the blue fill and focus adds a white ring on top of whatever it lands on.
+  Order matters: the focused+selected pair has to match before either alone.
+-->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_focused="true" android:state_selected="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/anilist_blue" />
+            <stroke android:width="2dp" android:color="@color/netflix_white" />
+        </shape>
+    </item>
+
     <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/netflix_card_background" />
+            <stroke android:width="2dp" android:color="@color/netflix_white" />
+        </shape>
+    </item>
+
+    <item android:state_selected="true">
         <shape android:shape="rectangle">
             <corners android:radius="8dp" />
             <solid android:color="@color/anilist_blue" />
         </shape>
     </item>
-    <item android:state_selected="true">
-        <shape android:shape="rectangle">
-            <corners android:radius="8dp" />
-            <solid android:color="#3302A9FF" />
-            <stroke android:width="1dp" android:color="@color/anilist_blue" />
-        </shape>
-    </item>
+
     <item>
         <shape android:shape="rectangle">
             <corners android:radius="8dp" />

--- a/app/src/main/res/drawable/ic_anilist_badge.xml
+++ b/app/src/main/res/drawable/ic_anilist_badge.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  The AniList mark on its rounded brand tile, for the profile rail. The rail's
+  ImageView tints its icon, so the mark is drawn white and the tile carries the
+  colour — a tint applied to a flat vector would repaint the whole badge.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="5dp" />
+            <solid android:color="@color/anilist_blue" />
+        </shape>
+    </item>
+    <item
+        android:bottom="4dp"
+        android:left="4dp"
+        android:right="4dp"
+        android:top="4dp">
+        <vector
+            android:width="18dp"
+            android:height="18dp"
+            android:viewportWidth="863"
+            android:viewportHeight="605">
+            <path
+                android:fillColor="#FFFFFFFF"
+                android:pathData="M162.4,440.7V0H0v483.7c0,66.9 34.7,101.6 101.6,101.6h318.4l-20.7,-144.6H162.4z" />
+            <path
+                android:fillColor="#FFFFFFFF"
+                android:pathData="M646.5,0H400.3l193.7,585.3h269L646.5,0zM548.1,348.4L471.2,118.6l76.9,229.8z" />
+        </vector>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/ic_anilist_mark.xml
+++ b/app/src/main/res/drawable/ic_anilist_mark.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="863"
+    android:viewportHeight="605">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M162.4,440.7V0H0v483.7c0,66.9 34.7,101.6 101.6,101.6h318.4l-20.7,-144.6H162.4z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M646.5,0H400.3l193.7,585.3h269L646.5,0zM548.1,348.4L471.2,118.6l76.9,229.8z" />
+</vector>

--- a/app/src/main/res/layout/anilist_entry_dialog.xml
+++ b/app/src/main/res/layout/anilist_entry_dialog.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="520dp"
     android:layout_height="wrap_content"
-    android:background="@drawable/background_login_dialog"
+    android:background="@drawable/anilist_dialog_bg"
     android:orientation="vertical"
     android:padding="22dp">
 

--- a/app/src/main/res/layout/custom_tv_keyboard.xml
+++ b/app/src/main/res/layout/custom_tv_keyboard.xml
@@ -23,7 +23,7 @@
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:background="@color/netflix_background_primary"
-    android:padding="4dp">
+    android:padding="6dp">
 
     <LinearLayout
         android:id="@+id/letters_page"
@@ -41,82 +41,82 @@
         <TextView
             android:id="@+id/key_1"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="1" />
         <TextView
             android:id="@+id/key_2"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="2" />
         <TextView
             android:id="@+id/key_3"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="3" />
         <TextView
             android:id="@+id/key_4"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="4" />
         <TextView
             android:id="@+id/key_5"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="5" />
         <TextView
             android:id="@+id/key_6"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="6" />
         <TextView
             android:id="@+id/key_7"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="7" />
         <TextView
             android:id="@+id/key_8"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="8" />
         <TextView
             android:id="@+id/key_9"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="9" />
         <TextView
             android:id="@+id/key_0"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="0" />
     </LinearLayout>
 
@@ -130,82 +130,82 @@
         <TextView
             android:id="@+id/key_q"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="q" />
         <TextView
             android:id="@+id/key_w"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="w" />
         <TextView
             android:id="@+id/key_e"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="e" />
         <TextView
             android:id="@+id/key_r"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="r" />
         <TextView
             android:id="@+id/key_t"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="t" />
         <TextView
             android:id="@+id/key_y"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="y" />
         <TextView
             android:id="@+id/key_u"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="u" />
         <TextView
             android:id="@+id/key_i"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="i" />
         <TextView
             android:id="@+id/key_o"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="o" />
         <TextView
             android:id="@+id/key_p"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="p" />
     </LinearLayout>
 
@@ -219,74 +219,74 @@
         <TextView
             android:id="@+id/key_a"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="a" />
         <TextView
             android:id="@+id/key_s"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="s" />
         <TextView
             android:id="@+id/key_d"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="d" />
         <TextView
             android:id="@+id/key_f"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="f" />
         <TextView
             android:id="@+id/key_g"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="g" />
         <TextView
             android:id="@+id/key_h"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="h" />
         <TextView
             android:id="@+id/key_j"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="j" />
         <TextView
             android:id="@+id/key_k"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="k" />
         <TextView
             android:id="@+id/key_l"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="l" />
     </LinearLayout>
 
@@ -300,58 +300,58 @@
         <TextView
             android:id="@+id/key_z"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="z" />
         <TextView
             android:id="@+id/key_x"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="x" />
         <TextView
             android:id="@+id/key_c"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="c" />
         <TextView
             android:id="@+id/key_v"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="v" />
         <TextView
             android:id="@+id/key_b"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="b" />
         <TextView
             android:id="@+id/key_n"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="n" />
         <TextView
             android:id="@+id/key_m"
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="m" />
     </LinearLayout>
 
@@ -373,59 +373,59 @@
 
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="&#39;" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="&quot;" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text=":" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text=";" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="-" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="_" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="." />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="," />
     </LinearLayout>
 
@@ -438,59 +438,59 @@
 
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="!" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="?" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="(" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text=")" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="[" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="]" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="&amp;" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="#" />
     </LinearLayout>
 
@@ -503,59 +503,59 @@
 
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="@" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="+" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="*" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="=" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="%" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="$" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="/" />
         <TextView
             style="@style/KeyboardKey"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
-            android:textSize="@dimen/tv_text_body"
+            android:layout_width="@dimen/tv_keyboard_key"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
+            android:textSize="@dimen/tv_keyboard_key_text"
             android:text="~" />
     </LinearLayout>
 
@@ -570,34 +570,34 @@
         <TextView
             android:id="@+id/key_toggle"
             style="@style/KeyboardKey"
-            android:layout_width="56dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
+            android:layout_width="@dimen/tv_keyboard_key_wide"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
             android:textSize="@dimen/tv_text_label"
             android:text="123#" />
         <TextView
             android:id="@+id/key_space"
             style="@style/KeyboardKey"
-            android:layout_width="140dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
+            android:layout_width="@dimen/tv_keyboard_key_space"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
             android:textSize="@dimen/tv_text_label"
             android:text="SPACE" />
         <TextView
             android:id="@+id/key_backspace"
             style="@style/KeyboardKey"
-            android:layout_width="56dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
+            android:layout_width="@dimen/tv_keyboard_key_wide"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
             android:textSize="@dimen/tv_text_label"
             android:text="DEL" />
 
         <TextView
             android:id="@+id/key_clear"
             style="@style/KeyboardKey"
-            android:layout_width="56dp"
-            android:layout_height="32dp"
-            android:layout_margin="1dp"
+            android:layout_width="@dimen/tv_keyboard_key_wide"
+            android:layout_height="@dimen/tv_keyboard_key"
+            android:layout_margin="@dimen/tv_keyboard_key_gap"
             android:textSize="@dimen/tv_text_label"
             android:text="CLR" />
     </LinearLayout>

--- a/app/src/main/res/layout/search_item.xml
+++ b/app/src/main/res/layout/search_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="140dp"
     android:layout_height="180dp"
@@ -57,6 +58,22 @@
                     android:shadowDx="1"
                     android:shadowDy="1"
                     android:shadowRadius="2" />
+
+                <TextView
+                    android:id="@+id/movieSource"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:background="@drawable/anilist_chip_bg"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:paddingHorizontal="6dp"
+                    android:paddingVertical="1dp"
+                    android:textColor="@color/netflix_white"
+                    android:textSize="@dimen/tv_text_caption"
+                    android:visibility="gone"
+                    tools:text="AnimePahe"
+                    tools:visibility="visible" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/search_screen.xml
+++ b/app/src/main/res/layout/search_screen.xml
@@ -65,7 +65,7 @@
             <LinearLayout
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
-                android:layout_weight="1.3"
+                android:layout_weight="1.7"
                 android:orientation="vertical"
                 android:paddingHorizontal="8dp">
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -57,4 +57,22 @@
     <dimen name="tv_text_label">14sp</dimen>
     <dimen name="tv_text_body">16sp</dimen>
     <dimen name="tv_text_subtitle">18sp</dimen>
+
+    <!--
+      On-screen keyboard. Sized against the column it lives in, not guessed:
+      the widest row is ten keys, and the column is 1.7 of a 3.3 weight split.
+      The narrowest real TV is 720p at density 1.5, i.e. 853dp wide, which
+      leaves the column ~439dp — so the row must stay under that.
+
+        10 x (36 + 2*2) + 12 padding + 16 side padding = 428dp
+
+      No screen-size qualifiers on purpose: `sw` buckets key off the SHORTER
+      edge, and a 1080p TV is only 540dp tall, so every panel would land in the
+      same bucket and the qualifier would do nothing.
+    -->
+    <dimen name="tv_keyboard_key">36dp</dimen>
+    <dimen name="tv_keyboard_key_wide">62dp</dimen>
+    <dimen name="tv_keyboard_key_space">156dp</dimen>
+    <dimen name="tv_keyboard_key_gap">2dp</dimen>
+    <dimen name="tv_keyboard_key_text">18sp</dimen>
 </resources>


### PR DESCRIPTION
Five things from your screenshots.

## Two tabs looked active at once

Selection painted the tab translucent-blue, focus painted it solid blue — so the filter you were *reading* and the tab the d-pad happened to *sit on* both looked chosen.

Selection now owns the blue fill; focus adds a white ring on top of whatever it lands on. One tab is blue, always.

## The rail used a bookmark icon for AniList

The same icon as **Bookmarks Page**, two rows apart. It is the AniList mark now, on its rounded brand tile.

It opts out of the rail's icon tint — the rail tints icons to follow focus, and a tint applied to a flat vector repaints the whole badge rather than just the mark.

## The entry dialog had no panel

It borrowed `background_login_dialog`, which is `#4D000000`. Over a dark screen that is barely a tint, so the buttons floated over the grid behind them. It has its own opaque background now.

## The search keyboard

Keys **32dp → 36dp**, text **16sp → 18sp**, gaps doubled.

You said make it bigger *without* it colliding, so I sized it against the column it actually lives in rather than picking a number:

| | |
|---|---|
| widest row | 10 keys → **428dp** |
| narrowest real TV | 720p @ density 1.5 = 853dp wide |
| that column, at weight 1.7/3.3 | **439dp** |

Fits there, and everywhere larger. The keyboard column went 1.4 → 1.7, so the results grid gives up a little width.

**Worth recording:** I first reached for `values-sw600dp`/`sw720dp` qualifiers. They are useless here — `sw` keys off the *shorter* edge, and a 1080p TV is only 540dp tall, so every panel lands in the same bucket. Caught it by checking the arithmetic before shipping three dimens folders.

## Results say which source found them

In an all-sources search the same title comes back from several providers. Without a label the duplicates read as a bug rather than a choice of where to play from.

Resolved from the content registry, so no model change — and shown only when the search actually spans sources.

Builds, 24 tests pass. Not run on a device.