### PR TITLE
TV: act on the phone's remote

### DIFF
--- a/app/src/main/java/com/saikou/sozo_tv/data/remote/remote/RemoteControlClient.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/remote/remote/RemoteControlClient.kt
@@ -1,0 +1,162 @@
+package com.saikou.sozo_tv.data.remote.remote
+
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.BufferedReader
+import java.util.concurrent.TimeUnit
+
+/** One instruction from the phone. Unknown types are dropped by the caller, not here. */
+data class RemoteCommand(
+    val type: String,
+    val positionMs: Long? = null,
+    val deltaMs: Long? = null,
+    /** Volume only. Typed text arrives as [text] — one key, one type. */
+    val value: Double? = null,
+    val text: String? = null,
+    val direction: String? = null,
+    val contentUrl: String? = null,
+    val provider: String? = null,
+    val title: String? = null,
+    val episodeIndex: Int? = null,
+)
+
+/** What this TV is doing, sent up so the phone's remote can show it. */
+data class RemoteState(
+    val deviceId: String,
+    val screen: String? = null,
+    val title: String? = null,
+    val episode: String? = null,
+    val playing: Boolean = false,
+    val positionMs: Long? = null,
+    val durationMs: Long? = null,
+)
+
+/**
+ * The TV's end of the remote-control channel.
+ *
+ * Holds one long-lived SSE connection and hands each command to [onCommand]. The
+ * caller owns reconnection — this class deliberately returns when the stream
+ * ends rather than looping, so the retry policy (and its backoff) lives in one
+ * place next to the lifecycle that should stop it.
+ *
+ * The stream is parsed by hand instead of pulling in okhttp-sse: the server
+ * sends `event:` / `data:` pairs and comment heartbeats, which is the whole of
+ * the protocol we use, and a dependency for that is not worth its APK size.
+ */
+class RemoteControlClient(
+    okHttpClient: OkHttpClient,
+    private val gson: Gson,
+    private val baseUrl: String,
+    private val tokenProvider: suspend () -> String?,
+) {
+
+    // The stream never goes quiet for long — the server heartbeats every 25s —
+    // but it must never be read-timed-out for being idle between commands.
+    private val streamClient: OkHttpClient = okHttpClient.newBuilder()
+        .readTimeout(0, TimeUnit.MILLISECONDS)
+        .retryOnConnectionFailure(true)
+        .build()
+
+    private val postClient: OkHttpClient = okHttpClient
+
+    /**
+     * Opens the channel and blocks until it closes.
+     *
+     * Returns normally on a clean close and throws on a transport failure, so
+     * the caller can tell "the server let go" from "the network is gone" —
+     * they deserve different backoff.
+     */
+    suspend fun stream(
+        deviceId: String,
+        onOpen: () -> Unit,
+        onCommand: (RemoteCommand) -> Unit,
+    ) = withContext(Dispatchers.IO) {
+        val token = tokenProvider() ?: throw IllegalStateException("No access token")
+
+        val request = Request.Builder()
+            .url("${baseUrl.trimEnd('/')}$PATH_STREAM?deviceId=$deviceId")
+            .addHeader("Authorization", "Bearer $token")
+            .addHeader("Accept", "text/event-stream")
+            .addHeader("Cache-Control", "no-cache")
+            .build()
+
+        streamClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw RemoteStreamException(response.code)
+            }
+            onOpen()
+
+            val reader = response.body.charStream().buffered()
+            var event: String? = null
+            val data = StringBuilder()
+
+            reader.forEachLineCancellable { line ->
+                when {
+                    // A comment. The heartbeat arrives as one; it exists to keep
+                    // proxies from dropping us, and carries nothing to parse.
+                    line.startsWith(":") -> Unit
+
+                    line.startsWith("event:") -> event = line.removePrefix("event:").trim()
+
+                    line.startsWith("data:") -> {
+                        if (data.isNotEmpty()) data.append('\n')
+                        data.append(line.removePrefix("data:").trim())
+                    }
+
+                    // Blank line ends an event.
+                    line.isEmpty() -> {
+                        if (event == "command" && data.isNotEmpty()) {
+                            parse(data.toString())?.let(onCommand)
+                        }
+                        event = null
+                        data.setLength(0)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun parse(json: String): RemoteCommand? = try {
+        gson.fromJson(json, RemoteCommand::class.java)?.takeIf { it.type.isNotBlank() }
+    } catch (_: JsonSyntaxException) {
+        // A malformed frame must not tear down a working channel.
+        null
+    }
+
+    /** Best effort: the phone showing a slightly stale position beats a crash. */
+    suspend fun report(state: RemoteState): Boolean = withContext(Dispatchers.IO) {
+        val token = tokenProvider() ?: return@withContext false
+        val request = Request.Builder()
+            .url("${baseUrl.trimEnd('/')}$PATH_STATE")
+            .addHeader("Authorization", "Bearer $token")
+            .addHeader("Content-Type", "application/json")
+            .post(gson.toJson(state).toRequestBody(JSON))
+            .build()
+
+        runCatching {
+            postClient.newCall(request).execute().use { it.isSuccessful }
+        }.getOrDefault(false)
+    }
+
+    private inline fun BufferedReader.forEachLineCancellable(action: (String) -> Unit) {
+        while (true) {
+            val line = readLine() ?: return
+            action(line)
+        }
+    }
+
+    companion object {
+        const val PATH_STREAM = "/remote/stream"
+        const val PATH_STATE = "/remote/state"
+        private val JSON = "application/json; charset=utf-8".toMediaType()
+    }
+}
+
+/** Non-2xx on the stream itself. 401 means the token died; 404 means this session is gone. */
+class RemoteStreamException(val code: Int) : Exception("Remote stream failed: $code")

--- a/app/src/main/java/com/saikou/sozo_tv/data/repository/RemoteControlManager.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/data/repository/RemoteControlManager.kt
@@ -1,0 +1,148 @@
+package com.saikou.sozo_tv.data.repository
+
+import android.util.Log
+import com.saikou.sozo_tv.data.local.pref.DeviceSessionStore
+import com.saikou.sozo_tv.data.remote.remote.RemoteCommand
+import com.saikou.sozo_tv.data.remote.remote.RemoteControlClient
+import com.saikou.sozo_tv.data.remote.remote.RemoteState
+import com.saikou.sozo_tv.data.remote.remote.RemoteStreamException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import java.io.IOException
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Keeps the phone's channel to this TV open, and fans commands out to whoever
+ * is on screen.
+ *
+ * One connection for the whole app, owned here rather than by a screen: the
+ * channel has to survive navigation, and a phone pressing play while the TV
+ * sits on the home screen is the normal case, not an edge one.
+ */
+class RemoteControlManager(
+    private val client: RemoteControlClient,
+    private val store: DeviceSessionStore,
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var loop: Job? = null
+
+    // extraBufferCapacity, not replay: a command that arrived before a screen
+    // was listening is stale by the time it gets there, and replaying it would
+    // re-press a button the user pressed minutes ago.
+    private val _commands = MutableSharedFlow<RemoteCommand>(
+        replay = 0,
+        extraBufferCapacity = 16,
+    )
+    val commands: SharedFlow<RemoteCommand> get() = _commands
+
+    private val _connected = MutableStateFlow(false)
+    val connected: StateFlow<Boolean> get() = _connected
+
+    /** Starts following the session. Safe to call more than once. */
+    fun start() {
+        if (loop != null) return
+        loop = scope.launch {
+            // collectLatest so signing out cancels the in-flight connection
+            // instead of leaving it holding a socket for a session that is gone.
+            store.session.collectLatest { session ->
+                _connected.value = false
+                val deviceId = session?.sessionId
+                if (deviceId.isNullOrBlank()) return@collectLatest
+                connectForever(deviceId)
+            }
+        }
+    }
+
+    suspend fun stop() {
+        loop?.cancelAndJoin()
+        loop = null
+        _connected.value = false
+    }
+
+    private suspend fun connectForever(deviceId: String) {
+        var backoffMs = MIN_BACKOFF_MS
+
+        while (coroutineContext.isActive) {
+            try {
+                client.stream(
+                    deviceId = deviceId,
+                    onOpen = {
+                        _connected.value = true
+                        // Reset only once the server actually accepted us. Resetting
+                        // on attempt would turn a refused connection into a tight loop.
+                        backoffMs = MIN_BACKOFF_MS
+                    },
+                    onCommand = { command ->
+                        if (!_commands.tryEmit(command)) {
+                            Log.w(TAG, "command dropped, nobody listening: ${command.type}")
+                        }
+                    },
+                )
+                // Returned cleanly: the server closed the stream. Reconnect.
+                Log.d(TAG, "stream closed by server")
+            } catch (e: RemoteStreamException) {
+                _connected.value = false
+                if (e.code == 404) {
+                    // This device session no longer exists. Retrying cannot fix
+                    // it; the session flow will restart us if a new one arrives.
+                    Log.w(TAG, "device session gone, giving up until re-paired")
+                    return
+                }
+                // 401 included: accessToken() refreshes on the next attempt.
+                Log.w(TAG, "stream rejected: ${e.code}")
+            } catch (e: IOException) {
+                Log.d(TAG, "stream dropped: ${e.message}")
+            } catch (e: IllegalStateException) {
+                Log.w(TAG, "no token yet: ${e.message}")
+            }
+
+            _connected.value = false
+            delay(backoffMs)
+            backoffMs = (backoffMs * 2).coerceAtMost(MAX_BACKOFF_MS)
+        }
+    }
+
+    /** Reports what is on screen. Fire and forget — never block playback for this. */
+    fun report(
+        screen: String,
+        title: String? = null,
+        episode: String? = null,
+        playing: Boolean = false,
+        positionMs: Long? = null,
+        durationMs: Long? = null,
+    ) {
+        val deviceId = store.current()?.sessionId ?: return
+        if (!_connected.value) return
+        scope.launch {
+            client.report(
+                RemoteState(
+                    deviceId = deviceId,
+                    screen = screen,
+                    title = title,
+                    episode = episode,
+                    playing = playing,
+                    positionMs = positionMs,
+                    durationMs = durationMs,
+                )
+            )
+        }
+    }
+
+    companion object {
+        private const val TAG = "RemoteControl"
+        private const val MIN_BACKOFF_MS = 2_000L
+        private const val MAX_BACKOFF_MS = 60_000L
+    }
+}

--- a/app/src/main/java/com/saikou/sozo_tv/di/networkModule.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/di/networkModule.kt
@@ -16,6 +16,8 @@ import com.saikou.sozo_tv.data.repository.AnilistRepository
 import com.saikou.sozo_tv.data.repository.AnilistSourceRegistry
 import com.saikou.sozo_tv.data.repository.AnilistTracker
 import com.saikou.sozo_tv.data.repository.DeviceAuthRepository
+import com.saikou.sozo_tv.data.remote.remote.RemoteControlClient
+import com.saikou.sozo_tv.data.repository.RemoteControlManager
 import com.saikou.sozo_tv.data.repository.UserListsRepository
 import com.saikou.sozo_tv.data.repository.WatchHistorySyncRepository
 import okhttp3.OkHttpClient
@@ -57,6 +59,18 @@ val NetworkModule = module {
         )
     }
     single { UserListsRepository(context = androidContext(), client = get()) }
+
+    // The phone's remote. Same auth client and per-request token as the other
+    // authenticated APIs, so a mid-session refresh is picked up on reconnect.
+    single {
+        RemoteControlClient(
+            okHttpClient = get(named("authOkHttp")),
+            gson = get(),
+            baseUrl = BuildConfig.SOZO_API_BASE_URL,
+            tokenProvider = { get<DeviceAuthRepository>().accessToken() },
+        )
+    }
+    single { RemoteControlManager(client = get(), store = get()) }
 
     single {
         WatchHistorySyncClient(

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/activities/MainActivity.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/activities/MainActivity.kt
@@ -20,6 +20,13 @@ import com.saikou.sozo_tv.presentation.viewmodel.SettingsViewModel
 import com.saikou.sozo_tv.utils.LocalData
 import com.saikou.sozo_tv.utils.finishDeferred
 import com.saikou.sozo_tv.utils.loadImage
+import android.view.KeyEvent
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.saikou.sozo_tv.data.repository.RemoteControlManager
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 // AppCompatActivity (not FragmentActivity): CloudStream plugins cast the context handed to
@@ -27,6 +34,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 // extension engine loads them. `Theme.Tv` descends from Theme.MaterialComponents, so it qualifies.
 class MainActivity : AppCompatActivity() {
     private val model: SettingsViewModel by viewModel()
+    private val remote: RemoteControlManager by inject()
     private var _binding: ActivityMainBinding? = null
     private var headerBinding: ContentHeaderMenuMainTvBinding? = null
     private val binding get() = _binding!!
@@ -39,6 +47,80 @@ class MainActivity : AppCompatActivity() {
         model.loadProfile()
         setupNavigation()
         setupBackBehaviour()
+        observeRemote()
+    }
+
+    /**
+     * Acts on what the phone sends.
+     *
+     * Only the commands that are about getting somewhere live here — search
+     * text, opening a title, and the d-pad. Playback commands are handled by
+     * the player, which is the only thing that knows whether there is anything
+     * playing.
+     *
+     * repeatOnLifecycle(STARTED) so a backgrounded TV stops acting on presses:
+     * the channel stays open, but driving navigation while another app is in
+     * the foreground is not something a remote should do.
+     */
+    private fun observeRemote() {
+        remote.start()
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                remote.commands.collect { command ->
+                    when (command.type) {
+                        "text" -> command.text?.let(::openSearch)
+                        "open" -> command.title?.takeIf { it.isNotBlank() }?.let { openSearch(it) }
+                        "home" -> navigateHome()
+                        "back" -> onBackPressedDispatcher.onBackPressed()
+                        "dpad" -> command.direction?.let(::sendDpad)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Typing on the phone lands in the TV's search box.
+     *
+     * The reason the remote exists. Navigating there rather than injecting
+     * keystrokes into whatever happens to be focused: a d-pad cannot move a
+     * caret, so "type into the focused field" is only meaningful when that
+     * field is the search box anyway.
+     */
+    private fun openSearch(query: String) {
+        val text = query.trim()
+        if (text.isEmpty()) return
+        val navHostFragment =
+            supportFragmentManager.findFragmentById(binding.navMainFragment.id) as? NavHostFragment
+                ?: return
+        navHostFragment.navController.navigate(
+            R.id.search,
+            Bundle().apply {
+                putString(SearchScreen.ARG_QUERY, text)
+                putBoolean(SearchScreen.ARG_SEARCH_ALL, true)
+            },
+        )
+    }
+
+    private fun navigateHome() {
+        val navHostFragment =
+            supportFragmentManager.findFragmentById(binding.navMainFragment.id) as? NavHostFragment
+                ?: return
+        navHostFragment.navController.popBackStack(R.id.home, false)
+    }
+
+    /** Synthesised so the phone's arrows move focus exactly as the real remote's do. */
+    private fun sendDpad(direction: String) {
+        val code = when (direction) {
+            "up" -> KeyEvent.KEYCODE_DPAD_UP
+            "down" -> KeyEvent.KEYCODE_DPAD_DOWN
+            "left" -> KeyEvent.KEYCODE_DPAD_LEFT
+            "right" -> KeyEvent.KEYCODE_DPAD_RIGHT
+            "center" -> KeyEvent.KEYCODE_DPAD_CENTER
+            else -> return
+        }
+        dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, code))
+        dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, code))
     }
 
     private fun setupBackBehaviour() {

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
@@ -1,5 +1,10 @@
 package com.saikou.sozo_tv.presentation.screens.play
 
+import kotlinx.coroutines.delay
+import com.saikou.sozo_tv.data.repository.RemoteControlManager
+import com.saikou.sozo_tv.data.remote.remote.RemoteCommand
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.Lifecycle
 import eu.kanade.tachiyomi.network.interceptor.CloudflareInterceptor
 import com.saikou.sozo_tv.app.MyApp
 import com.saikou.sozo_tv.utils.SOZO_USER_AGENT
@@ -93,6 +98,7 @@ import java.util.concurrent.TimeUnit
 
 class SeriesPlayerScreen : Fragment() {
 
+    private val remote: RemoteControlManager by inject()
     private var _binding: SeriesPlayerScreenBinding? = null
     private val binding get() = _binding!!
 
@@ -333,6 +339,68 @@ class SeriesPlayerScreen : Fragment() {
         }
     }
 
+    /**
+     * Playback commands from the phone.
+     *
+     * Handled here rather than in MainActivity because this is the only place
+     * that knows whether anything is playing — and the phone's remote is
+     * useless if pressing pause depends on which screen the TV happens to show.
+     *
+     * repeatOnLifecycle(STARTED) is what stops a backgrounded player from
+     * acting on presses meant for whatever replaced it.
+     */
+    private fun observeRemote() {
+        remote.start()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch { remote.commands.collect(::handleRemote) }
+                launch { reportStateWhileVisible() }
+            }
+        }
+    }
+
+    private fun handleRemote(command: RemoteCommand) {
+        if (!::player.isInitialized) return
+        when (command.type) {
+            "play" -> player.play()
+            "pause" -> player.pause()
+            "playpause" -> if (player.isPlaying) player.pause() else player.play()
+            "stop" -> navigateBack()
+            "seek" -> command.positionMs?.let { player.seekTo(it.coerceAtLeast(0)) }
+            "seekBy" -> command.deltaMs?.let {
+                player.seekTo((player.currentPosition + it).coerceAtLeast(0))
+            }
+            "volume" -> command.value?.let {
+                player.volume = it.toFloat().coerceIn(0f, 1f)
+            }
+            "next" -> playNextEpisodeAutomatically()
+            "prev" -> playPreviousEpisode()
+        }
+    }
+
+    /**
+     * A heartbeat of what is on screen, so the phone's remote shows a moving
+     * position instead of a still one.
+     *
+     * Two seconds, not per frame: the remote renders seconds, and the report is
+     * a network call.
+     */
+    private suspend fun reportStateWhileVisible() {
+        while (true) {
+            if (::player.isInitialized && _binding != null) {
+                remote.report(
+                    screen = "player",
+                    title = args.name,
+                    episode = episodeList.getOrNull(model.currentEpIndex)?.episode?.toString(),
+                    playing = player.isPlaying,
+                    positionMs = player.currentPosition.coerceAtLeast(0),
+                    durationMs = player.duration.takeIf { it > 0 },
+                )
+            }
+            delay(2_000)
+        }
+    }
+
     private fun navigateBack() {
         if (!isAdded) return
 
@@ -346,6 +414,39 @@ class SeriesPlayerScreen : Fragment() {
     }
 
     @SuppressLint("StringFormatMatches")
+    /**
+     * The mirror of [playNextEpisodeAutomatically], for the phone's back button.
+     *
+     * Nothing on the TV itself moves backwards through episodes — the d-pad has
+     * a previous button but it seeks — so this had no reason to exist until the
+     * remote gained one.
+     */
+    private fun playPreviousEpisode() {
+        if (model.currentEpIndex <= 0) return
+        lifecycleScope.launch {
+            saveWatchHistory()
+            withContext(Dispatchers.Main) {
+                model.currentEpIndex -= 1
+                model.doNotAsk = false
+                model.lastPosition = 0
+
+                model.getCurrentEpisodeVodAnime(
+                    episodeList[model.currentEpIndex].session.toString(), args.seriesMainId,
+                    episodeNum = episodeList[model.currentEpIndex].episode ?: 0
+                )
+
+                model.currentEpisodeData.observeOnce(viewLifecycleOwner) { resource ->
+                    if (resource is Resource.Success) {
+                        playNewEpisode(resource.data.urlobj, headers = resource.data.header)
+                        binding.pvPlayer.controller.binding.filmTitle.text =
+                            getString(R.string.episode, args.name, model.currentEpIndex + 1)
+                        resetCountdownState()
+                    }
+                }
+            }
+        }
+    }
+
     private fun playNextEpisodeAutomatically() {
         if (model.currentEpIndex < episodeList.size - 1) {
             lifecycleScope.launch {
@@ -466,6 +567,7 @@ class SeriesPlayerScreen : Fragment() {
         })
 
         binding.pvPlayer.player = player
+        observeRemote()
         binding.pvPlayer.controller.binding.exoNextTenContainer.setOnClickListener {
             player.seekTo(player.currentPosition + 10_000)
         }


### PR DESCRIPTION
The TV end of the remote channel. Backend is **sozo-backend#13**; the phone is **sozo#…** (mobile branch).

> Stacked on **#17** — it was written against that branch and shares `SeriesPlayerScreen`. Merge #17 first.

### Shape
One SSE connection held for the life of the app, reconnecting with backoff, fanning commands out to whichever screen can act on them.

Owned by `RemoteControlManager` rather than a screen. The channel has to survive navigation, and a phone pressing play while the TV sits on the home screen is the normal case, not an edge one.

- **MainActivity** — typed text, opening a title, d-pad, back, home.
- **SeriesPlayerScreen** — play, pause, seek, volume, next/previous episode, and a two-second state report so the phone's remote shows a moving position.

Both collect under `repeatOnLifecycle(STARTED)`, so a backgrounded TV stops acting on presses meant for whatever replaced it while the channel stays open.

### Typing is the point
Entering text with a d-pad is the worst thing about any TV app — most of #17 was about that keyboard. The phone already has a real one.

It navigates to search rather than injecting keystrokes into whatever happens to be focused: a d-pad cannot move a caret, so "type into the focused field" is only meaningful when that field is the search box anyway.

### Decisions
**The stream is parsed by hand** instead of adding `okhttp-sse`. The server sends `event:`/`data:` pairs and comment heartbeats — that is the whole protocol — and the read timeout is disabled on that client alone, since it must never be timed out for being idle between commands.

**Backoff resets when the server accepts us, not when we attempt.** Resetting on attempt turns a refused connection into a tight loop.

**A 404 stops the loop.** A device session that no longer exists cannot be retried into existence; the session flow restarts it if the TV is paired again.

**A malformed frame is dropped, not fatal.** One bad JSON payload must not tear down a working channel.

### Two protocol corrections this branch forced
Both were found by writing the client, and are fixed in sozo-backend#13:

- `text` carried its payload in `value`, which volume already uses for a number. The Kotlin model would not compile against it — the good version of that discovery. It has its own `text` key now.
- `open` required a `contentUrl`. The apps do not share a source registry: a url from the phone's provider means nothing to a TV that does not have it installed, and the TV opens content by its own registry id. The **title** travels now, and the TV resolves it against its own sources.

### Also here
`playPreviousEpisode` had no reason to exist until now — nothing on the TV moves backwards through episodes, the d-pad's previous button seeks — so it is added as the mirror of the automatic next.

---

Builds; the 24 existing unit tests still pass. Not verified: an end-to-end run against a real paired TV, which needs both apps and a server.
