### PR TITLE
ci: say which version a run is shipping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release → Telegram
+run-name: >-
+  Release ${{ inputs.version != '' && inputs.version || inputs.bump || github.ref_name }}
 
 # Builds a signed Android TV APK and hands it to Telegram.
 #
@@ -89,6 +91,8 @@ jobs:
             echo "::error title=Malformed versionName::could not read it from ${GRADLE}"; exit 1
           fi
 
+          echo "::notice title=Current version::${NAME} (versionCode ${CODE})"
+
           if [ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]; then
             echo "Tag build — using the committed version verbatim."
             NEW_NAME="${NAME}"
@@ -131,6 +135,8 @@ jobs:
             echo ""
             echo "Publish \`versionCode ${NEW_CODE}\` on the admin panel under platform **androidtv** for the in-app updater to offer it."
           } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::notice title=Releasing::${NEW_NAME} (versionCode ${NEW_CODE})"
 
       - name: Commit and tag
         if: steps.resolve.outputs.bumped == 'yes'


### PR DESCRIPTION
Every run in the Actions list reads `Release → Telegram`, so telling which one shipped what means opening it and scrolling.

- **Run name** now carries the requested bump, or the exact version when one was typed.
- The **current** `versionName` and `versionCode` are annotated before anything changes, and the **resolved** ones after.

Annotations sit at the top of the run page. The job summary already had a was/now table, but it only appears once the bump has already happened — and choosing between a patch and a minor needs the number you are raising *from*.

The resolved `versionCode` is also annotated because that is the value that has to be published on the admin panel under **androidtv** for the in-app updater to offer the build.

No behaviour change: nothing about what gets built, tagged or sent moves.