### PR TITLE
Let the player pick audio, subtitles and speed

### DIFF
--- a/app/src/main/java/com/saikou/sozo_tv/domain/player/NativeTracks.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/domain/player/NativeTracks.kt
@@ -1,0 +1,129 @@
+package com.saikou.sozo_tv.domain.player
+
+import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.TrackSelectionOverride
+import androidx.media3.common.Tracks
+import java.util.Locale
+
+/**
+ * The audio and subtitle tracks a stream already carries.
+ *
+ * The player has always had these — ExoPlayer parses every rendition in the
+ * manifest — and the UI simply never asked. So a dual-audio release played
+ * whichever track the preferred-language list happened to match, with no way to
+ * say otherwise, and subtitles burned into the manifest were invisible next to
+ * the ones the extractor supplied separately.
+ *
+ * Nothing here fetches anything. It reads what the player already knows and
+ * turns it into something a person can choose from.
+ */
+object NativeTracks {
+
+    data class Option(
+        val label: String,
+        val detail: String,
+        val group: Tracks.Group,
+        val index: Int,
+    )
+
+    /** Empty when there is nothing to choose between — one track is not a choice. */
+    fun audio(tracks: Tracks): List<Option> = collect(tracks, C.TRACK_TYPE_AUDIO) { format ->
+        languageOf(format) to audioDetail(format)
+    }
+
+    /**
+     * Subtitle tracks inside the stream.
+     *
+     * Returned even when there is only one, unlike audio: a single embedded
+     * subtitle track is still a choice, because the alternative is off.
+     */
+    fun text(tracks: Tracks): List<Option> =
+        collect(tracks, C.TRACK_TYPE_TEXT, keepSingle = true) { format ->
+            languageOf(format) to textDetail(format)
+        }
+
+    private fun collect(
+        tracks: Tracks,
+        type: Int,
+        keepSingle: Boolean = false,
+        describe: (Format) -> Pair<String, String>,
+    ): List<Option> {
+        val out = mutableListOf<Option>()
+        for (group in tracks.groups) {
+            if (group.type != type) continue
+            for (i in 0 until group.length) {
+                // An unsupported track is one this device cannot decode. Offering
+                // it means offering silence.
+                if (!group.isTrackSupported(i)) continue
+                val format = group.getTrackFormat(i)
+                val (label, detail) = describe(format)
+                out += Option(label, detail, group, i)
+            }
+        }
+        // Same language twice with the same detail is a manifest artefact, not
+        // two choices.
+        val distinct = out.distinctBy { it.label to it.detail }
+        return if (keepSingle || distinct.size > 1) distinct else emptyList()
+    }
+
+    /**
+     * A name for the track.
+     *
+     * The manifest's own label wins when it has one — it is what the publisher
+     * chose to call it, and "Hindi 5.1 Commentary" beats anything derivable.
+     * Otherwise the language code is turned into a real language name, because
+     * "hin" is not something to put in front of a viewer.
+     */
+    private fun languageOf(format: Format): String {
+        format.label?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
+        val code = format.language?.trim().orEmpty()
+        if (code.isEmpty() || code == "und") return "Noma'lum"
+        val display = runCatching { Locale.forLanguageTag(code).displayLanguage }
+            .getOrNull().orEmpty()
+        return if (display.isNotEmpty() && !display.equals(code, ignoreCase = true)) {
+            display.replaceFirstChar { it.uppercase() }
+        } else {
+            code.uppercase()
+        }
+    }
+
+    private fun audioDetail(format: Format): String = buildList {
+        when (format.channelCount) {
+            1 -> add("Mono")
+            2 -> add("Stereo")
+            6 -> add("5.1")
+            8 -> add("7.1")
+            else -> if (format.channelCount > 0) add("${format.channelCount}ch")
+        }
+        codecName(format.codecs)?.let { add(it) }
+        if (format.bitrate > 0) add("${format.bitrate / 1000} kbps")
+        if (format.roleFlags and C.ROLE_FLAG_DESCRIBES_VIDEO != 0) add("Audio-tavsif")
+    }.joinToString(" · ")
+
+    private fun textDetail(format: Format): String = buildList {
+        if (format.roleFlags and C.ROLE_FLAG_SUBTITLE != 0) add("Subtitr")
+        if (format.roleFlags and C.ROLE_FLAG_CAPTION != 0) add("CC")
+        if (format.selectionFlags and C.SELECTION_FLAG_FORCED != 0) add("Majburiy")
+        add("Oqim ichida")
+    }.joinToString(" · ")
+
+    /** The bit of a codec string worth showing — "mp4a.40.2" tells a viewer nothing. */
+    private fun codecName(codecs: String?): String? {
+        val raw = codecs?.substringBefore('.')?.lowercase() ?: return null
+        return when {
+            raw.startsWith("mp4a") -> "AAC"
+            raw.startsWith("ac-3") || raw.startsWith("ac3") -> "AC-3"
+            raw.startsWith("ec-3") || raw.startsWith("ec3") -> "E-AC-3"
+            raw.startsWith("opus") -> "Opus"
+            raw.startsWith("vorbis") -> "Vorbis"
+            raw.startsWith("dts") -> "DTS"
+            raw.startsWith("flac") -> "FLAC"
+            raw.isEmpty() -> null
+            else -> raw.uppercase()
+        }
+    }
+
+    fun overrideFor(option: Option): TrackSelectionOverride =
+        TrackSelectionOverride(option.group.mediaTrackGroup, option.index)
+}

--- a/app/src/main/java/com/saikou/sozo_tv/engine/player/WebViewStreamExtractor.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/engine/player/WebViewStreamExtractor.kt
@@ -54,11 +54,18 @@ object WebViewStreamExtractor {
         "googletagmanager.com", "doubleclick.net", "googlesyndication.com", "adservice",
     )
 
+    // Player-page path segments. An /embed/<token> url carries no extension, so the
+    // suffix checks below cannot see it. Kept deliberately narrow — a short alias
+    // like "/e/" also appears mid-path on plain CDNs, and a false positive here
+    // costs a 20s WebView on a url ExoPlayer could have played directly.
+    private val PAGE_SEGMENTS = listOf("/embed/", "/player/")
+
     /** True when [url] is an HTML page we must open in a WebView to discover the real stream. */
     fun needsExtraction(url: String): Boolean {
         val path = url.substringBefore('?').lowercase()
         // Already a direct stream/file → no extraction.
         if (DIRECT_EXT.any { path.contains(it) }) return false
+        if (PAGE_SEGMENTS.any { path.contains(it) }) return true
         // Only clear content pages need sniffing. Extensionless/query endpoints are usually
         // already-direct streams — don't spend a 20s WebView on them (false positive penalty).
         return path.endsWith(".html") || path.endsWith(".htm") ||
@@ -75,11 +82,19 @@ object WebViewStreamExtractor {
         pageUrl: String,
         pageHeaders: Map<String, String> = emptyMap(),
         timeoutMs: Long = 20_000L,
+        patterns: List<String> = STREAM_PATS,
+        blockHosts: List<String> = emptyList(),
     ): ExtractedStream? = suspendCancellableCoroutine { cont ->
         val main = Handler(Looper.getMainLooper())
         var webView: WebView? = null
         val settled = java.util.concurrent.atomic.AtomicBoolean(false)
         val hit = java.util.concurrent.atomic.AtomicReference<ExtractedStream?>(null)
+        // Position in [pats] of the current hit. Patterns are PRIORITY-ordered, so a
+        // late .m3u8 still displaces an .mp4 ad creative that arrived first.
+        val hitRank = java.util.concurrent.atomic.AtomicInteger(Int.MAX_VALUE)
+
+        val pats = patterns.ifEmpty { STREAM_PATS }.map { it.lowercase() }
+        val block = BLOCK + blockHosts.map { it.lowercase() }
 
         val cleanup = {
             main.post {
@@ -133,11 +148,13 @@ object WebViewStreamExtractor {
                     val url = request.url.toString()
                     val lower = url.lowercase()
 
-                    if (BLOCK.any { lower.contains(it) }) {
+                    if (block.any { lower.contains(it) }) {
                         return WebResourceResponse("text/plain", "utf-8", ByteArrayInputStream(ByteArray(0)))
                     }
                     if (settled.get()) return null
-                    STREAM_PATS.firstOrNull { lower.substringBefore('?').contains(it) } ?: return null
+                    val bare = lower.substringBefore('?')
+                    val rank = pats.indexOfFirst { bare.contains(it) }
+                    if (rank < 0 || rank >= hitRank.get()) return null
 
                     val headers = buildMap {
                         request.requestHeaders
@@ -148,13 +165,13 @@ object WebViewStreamExtractor {
                         put("Referer", streamReferer)
                         putIfAbsent("Origin", streamOrigin)
                     }
-                    val playType = if (lower.substringBefore('?').contains(".mp4")) "mp4" else "hls"
+                    val playType = if (bare.contains(".mp4")) "mp4" else "hls"
                     android.util.Log.i("StreamExtract", "captured $playType: $url")
                     android.util.Log.i("StreamExtract", "replaying headers: ${headers.keys.sorted()}")
 
-                    if (hit.compareAndSet(null, ExtractedStream(url, headers, playType))) {
-                        main.postDelayed(settle, SETTLE_MS)
-                    }
+                    val isFirst = hitRank.getAndSet(rank) == Int.MAX_VALUE
+                    hit.set(ExtractedStream(url, headers, playType))
+                    if (isFirst) main.postDelayed(settle, SETTLE_MS)
                     return null
                 }
             }

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
@@ -31,7 +31,10 @@ import androidx.annotation.OptIn
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.media3.common.Tracks
+import com.saikou.sozo_tv.data.model.SubTitle
 import com.saikou.sozo_tv.domain.player.NativeQualities
+import com.saikou.sozo_tv.domain.player.NativeTracks
 import com.saikou.sozo_tv.domain.player.VideoOptionGroups
 import com.saikou.sozo_tv.adapters.VideoServersAdapter
 import com.saikou.sozo_tv.data.extensions.ExtensionEngine
@@ -107,6 +110,9 @@ class SeriesPlayerScreen : Fragment() {
     @OptIn(UnstableApi::class)
     private var trackSelector: DefaultTrackSelector? = null
     private var selectedNativeQuality: NativeQualities.Variant? = null
+    private var selectedAudio: NativeTracks.Option? = null
+    private var selectedText: NativeTracks.Option? = null
+    private var playbackSpeed = 1.0f
     private lateinit var dataSourceFactory: DataSource.Factory
     private var okHttpClient: OkHttpClient? = null
 
@@ -518,6 +524,26 @@ class SeriesPlayerScreen : Fragment() {
         }
 
         player.addListener(object : Player.Listener {
+            /**
+             * What a stream carries is only known once it has been parsed, so the
+             * controls that depend on it are decided here rather than at bind
+             * time — a dual-audio release and a mono one get different buttons.
+             */
+            @OptIn(UnstableApi::class)
+            override fun onTracksChanged(tracks: Tracks) {
+                // release() fires this on the way down, and it runs before
+                // _binding is cleared — so the view may already be gone.
+                val b = _binding ?: return
+                val audio = NativeTracks.audio(tracks)
+                b.pvPlayer.controller.binding.exoAudio.isVisible = audio.size > 1
+                // A track the user picked cannot outlive the stream that
+                // declared it; the groups belong to that stream.
+                if (selectedAudio != null && audio.none { it.label == selectedAudio?.label }) {
+                    selectedAudio = null
+                }
+                refreshSubtitleButton()
+            }
+
             override fun onPlayerError(error: PlaybackException) {
                 Log.e("PLAYER_ERR", "code=${error.errorCodeName}", error)
                 showBuffering(false)
@@ -600,7 +626,6 @@ class SeriesPlayerScreen : Fragment() {
     }
 
     private var currentResizeIdx = 0
-    private var currentSpeedIdx = 2
 
     /** Wire the ⚙ settings button → screen-size (resize mode) + playback-speed menus. */
     @OptIn(UnstableApi::class)
@@ -628,19 +653,6 @@ class SeriesPlayerScreen : Fragment() {
             .setSingleChoiceItems(labels, currentResizeIdx) { d, i ->
                 currentResizeIdx = i
                 binding.pvPlayer.resizeMode = modes[i]
-                d.dismiss()
-            }
-            .show()
-    }
-
-    private fun showSpeedDialog() {
-        val speeds = floatArrayOf(0.5f, 0.75f, 1f, 1.25f, 1.5f, 2f)
-        val labels = speeds.map { if (it == 1f) "Normal (1x)" else "${it}x" }.toTypedArray()
-        androidx.appcompat.app.AlertDialog.Builder(requireContext())
-            .setTitle("Playback speed")
-            .setSingleChoiceItems(labels, currentSpeedIdx) { d, i ->
-                currentSpeedIdx = i
-                player.setPlaybackSpeed(speeds[i])
                 d.dismiss()
             }
             .show()
@@ -839,7 +851,11 @@ class SeriesPlayerScreen : Fragment() {
         // Track groups belong to the stream that declared them, so a pinned rendition cannot
         // survive a reload. Back to auto rather than to a stale override.
         selectedNativeQuality = null
+        selectedAudio = null
+        selectedText = null
         applyNativeQuality()
+        // Speed is the user's, not the stream's, so it is deliberately kept.
+        if (playbackSpeed != 1.0f) player.setPlaybackSpeed(playbackSpeed)
         player.prepare()
         player.seekTo(resumePos)
         player.play()
@@ -881,6 +897,157 @@ class SeriesPlayerScreen : Fragment() {
                 applyNativeQuality()
             }
         }.show(parentFragmentManager, "NativeQualityDialog")
+    }
+
+    /**
+     * Picks the audio track.
+     *
+     * No "auto" entry: unlike video quality there is nothing to adapt to — the
+     * player just follows the preferred-language list, which is a guess the user
+     * is now overruling. Listing the tracks and marking the current one is the
+     * whole of it.
+     */
+    @OptIn(UnstableApi::class)
+    private fun showAudioDialog() {
+        val options = NativeTracks.audio(player.currentTracks)
+        if (options.isEmpty()) return
+
+        val rows = options.map {
+            VideoServersAdapter.ServerRow(name = it.label, qualities = it.detail)
+        }
+        val current = selectedAudio?.let { chosen ->
+            options.indexOfFirst { it.label == chosen.label && it.detail == chosen.detail }
+        } ?: options.indexOfFirst { isPlaying(it) }
+
+        VideoServerDialog(
+            rows,
+            current.coerceAtLeast(0),
+            titleRes = R.string.player_audio_title,
+            subtitleRes = R.string.player_audio_subtitle,
+        ).apply {
+            setOnRowPicked { index ->
+                selectedAudio = options.getOrNull(index)
+                applyTrack(C.TRACK_TYPE_AUDIO, selectedAudio)
+            }
+        }.show(parentFragmentManager, "AudioTrackDialog")
+    }
+
+    /** Which track the player settled on, so the tick starts in the right place. */
+    @OptIn(UnstableApi::class)
+    private fun isPlaying(option: NativeTracks.Option): Boolean =
+        runCatching { option.group.isTrackSelected(option.index) }.getOrDefault(false)
+
+    /**
+     * Playback speed.
+     *
+     * Native to the player, so it costs nothing and survives a track change —
+     * and on a dubbed catalogue where a lot of the audio is slow, it is asked
+     * for more than most of what is already here.
+     */
+    private fun showSpeedDialog() {
+        val speeds = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f)
+        val rows = speeds.map {
+            VideoServersAdapter.ServerRow(
+                name = if (it == 1.0f) getString(R.string.player_speed_normal) else "${it}x",
+                qualities = "",
+            )
+        }
+        VideoServerDialog(
+            rows,
+            speeds.indexOfFirst { it == playbackSpeed }.coerceAtLeast(0),
+            titleRes = R.string.player_speed_title,
+            subtitleRes = R.string.player_speed_subtitle,
+        ).apply {
+            setOnRowPicked { index ->
+                playbackSpeed = speeds.getOrNull(index) ?: 1.0f
+                if (::player.isInitialized) player.setPlaybackSpeed(playbackSpeed)
+            }
+        }.show(parentFragmentManager, "PlaybackSpeedDialog")
+    }
+
+    /**
+     * Pins one track of [type], or hands the choice back to the player.
+     *
+     * Overrides are cleared by type rather than wholesale, so choosing an audio
+     * track cannot silently undo a pinned resolution.
+     */
+    @OptIn(UnstableApi::class)
+    private fun applyTrack(type: Int, option: NativeTracks.Option?) {
+        val selector = trackSelector ?: return
+        selector.setParameters(
+            selector.buildUponParameters()
+                .clearOverridesOfType(type)
+                // A text override means subtitles are wanted; without this the
+                // renderer stays disabled and the track is chosen but silent.
+                .setTrackTypeDisabled(type, false)
+                .apply { option?.let { addOverride(NativeTracks.overrideFor(it)) } }
+        )
+    }
+
+    /** The extractor's own subtitle files, if this episode came with any. */
+    private var extractorSubtitles: List<SubTitle> = emptyList()
+
+    @OptIn(UnstableApi::class)
+    private fun refreshSubtitleButton() {
+        if (!::player.isInitialized) return
+        val b = _binding ?: return
+        val embedded = NativeTracks.text(player.currentTracks)
+        b.pvPlayer.controller.binding.exoSubtidtle.isVisible =
+            extractorSubtitles.isNotEmpty() || embedded.isNotEmpty()
+    }
+
+    /**
+     * The subtitle tracks inside the stream, plus off.
+     *
+     * Separate from the extractor's dialog because the two are not the same
+     * operation: one is a track override the player applies instantly, the
+     * other rebuilds the media source around a downloaded file.
+     */
+    @OptIn(UnstableApi::class)
+    private fun showEmbeddedSubtitleDialog() {
+        val options = NativeTracks.text(player.currentTracks)
+        if (options.isEmpty()) return
+
+        val rows = buildList {
+            add(
+                VideoServersAdapter.ServerRow(
+                    name = getString(R.string.off),
+                    qualities = getString(R.string.player_subtitle_off_hint),
+                )
+            )
+            options.forEach { add(VideoServersAdapter.ServerRow(it.label, it.detail)) }
+        }
+        val current = selectedText
+            ?.let { chosen -> options.indexOfFirst { it.label == chosen.label } + 1 }
+            ?.coerceAtLeast(0) ?: 0
+
+        VideoServerDialog(
+            rows,
+            current,
+            titleRes = R.string.player_subtitle_title,
+            subtitleRes = R.string.player_subtitle_subtitle,
+        ).apply {
+            setOnRowPicked { index ->
+                selectedText = if (index == 0) null else options.getOrNull(index - 1)
+                val selector = trackSelector
+                if (index == 0 && selector != null) {
+                    // Off means off: clearing the override alone would let the
+                    // player pick a track again on the next selection pass.
+                    selector.setParameters(
+                        selector.buildUponParameters()
+                            .clearOverridesOfType(C.TRACK_TYPE_TEXT)
+                            .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
+                    )
+                } else {
+                    applyTrack(C.TRACK_TYPE_TEXT, selectedText)
+                }
+                binding.pvPlayer.subtitleView?.visibility =
+                    if (index == 0) View.GONE else View.VISIBLE
+                binding.pvPlayer.controller.binding.exoSubtitlee.setImageResource(
+                    if (index == 0) R.drawable.ic_subtitle else R.drawable.ic_subtitle_fill
+                )
+            }
+        }.show(parentFragmentManager, "EmbeddedSubtitleDialog")
     }
 
     @OptIn(UnstableApi::class)
@@ -933,13 +1100,29 @@ class SeriesPlayerScreen : Fragment() {
 
             player.play()
 
-            binding.pvPlayer.controller.binding.exoSubtidtle.isVisible = isSubtitleHave
+            // Visible when EITHER kind exists. It used to key off the extractor's
+            // list alone, so a stream carrying its own subtitle tracks showed no
+            // subtitle button at all — the tracks were parsed, selectable, and
+            // unreachable.
+            extractorSubtitles = subtitles
+            refreshSubtitleButton()
+
+            binding.pvPlayer.controller.binding.exoAudio.setOnClickListener { showAudioDialog() }
+            binding.pvPlayer.controller.binding.exoSpeed.setOnClickListener { showSpeedDialog() }
 
             binding.pvPlayer.controller.binding.exoPlayPaused.setImageResource(
                 if (player.isPlaying) R.drawable.anim_play_to_pause else R.drawable.anim_pause_to_play
             )
 
             binding.pvPlayer.controller.binding.exoSubtidtle.setOnClickListener {
+                // A stream's own subtitle tracks need no reload — they are
+                // already there, and picking one is a track override. Only the
+                // extractor's separate files require rebuilding the source, so
+                // that path is left exactly as it was.
+                if (subtitles.isEmpty()) {
+                    showEmbeddedSubtitleDialog()
+                    return@setOnClickListener
+                }
                 val currentSelected = subtitles.getOrNull(model.currentSubEpIndex)
                 val dialog =
                     SubtitleChooserDialog.newInstance(subtitles, currentSelected, isSubtitleHave)

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/PlayAnimeViewModel.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/PlayAnimeViewModel.kt
@@ -246,11 +246,14 @@ class PlayAnimeViewModel(
                 if (option.useWebViewSniff ||
                     com.saikou.sozo_tv.engine.player.WebViewStreamExtractor.needsExtraction(url)
                 ) {
+                    val directive = parseSniff(option.sniff)
                     val sniffed = com.saikou.sozo_tv.engine.player.WebViewStreamExtractor.extract(
                         context = com.saikou.sozo_tv.app.MyApp.context,
                         pageUrl = url,
-                        pageHeaders = option.headers,
-                        timeoutMs = sniffTimeoutMs(option.sniff),
+                        pageHeaders = option.headers + directive.headers,
+                        timeoutMs = directive.timeoutMs,
+                        patterns = directive.patterns,
+                        blockHosts = directive.blockHosts,
                     )
                     if (sniffed != null) {
                         url = sniffed.url
@@ -346,19 +349,43 @@ class PlayAnimeViewModel(
     }
 
     /**
-     * `sniff.timeoutMs` from the server's directive, clamped.
+     * The server's `sniff` directive: which requests count as the stream, which ad
+     * hosts to swallow, and how long to wait. Every field is optional and falls back
+     * to the extractor's own defaults, so an older backend keeps working unchanged.
      *
-     * Clamped rather than trusted: this value decides how long playback sits on a
-     * spinner, and a bad/hostile payload must not be able to hang the player. The
-     * default matches WebViewStreamExtractor's own.
+     * `timeoutMs` is clamped rather than trusted: it decides how long playback sits
+     * on a spinner, and a bad payload must not be able to hang the player.
      */
-    private fun sniffTimeoutMs(sniffJson: String?): Long {
-        val fallback = 20_000L
+    private data class SniffDirective(
+        val timeoutMs: Long,
+        val patterns: List<String>,
+        val blockHosts: List<String>,
+        val headers: Map<String, String>,
+    )
+
+    private fun parseSniff(sniffJson: String?): SniffDirective {
+        val fallback = SniffDirective(20_000L, emptyList(), emptyList(), emptyMap())
         if (sniffJson.isNullOrBlank()) return fallback
         return runCatching {
-            val v = org.json.JSONObject(sniffJson).optLong("timeoutMs", fallback)
-            v.coerceIn(5_000L, 45_000L)
+            val o = org.json.JSONObject(sniffJson)
+            SniffDirective(
+                timeoutMs = o.optLong("timeoutMs", fallback.timeoutMs).coerceIn(5_000L, 45_000L),
+                patterns = o.optJSONArray("patterns").strings(),
+                blockHosts = o.optJSONArray("blockHosts").strings(),
+                headers = o.optJSONObject("headers")?.let { h ->
+                    h.keys().asSequence().mapNotNull { k ->
+                        h.optString(k).takeIf { v -> v.isNotEmpty() }?.let { v -> k to v }
+                    }.toMap()
+                } ?: emptyMap(),
+            )
         }.getOrDefault(fallback)
+    }
+
+    private fun org.json.JSONArray?.strings(): List<String> {
+        val arr = this ?: return emptyList()
+        return (0 until arr.length()).mapNotNull { i ->
+            arr.optString(i).takeIf { it.isNotEmpty() }
+        }
     }
 
     private fun asException(t: Throwable): Exception = (t as? Exception) ?: Exception(t)

--- a/app/src/main/res/drawable/ic_audio_track.xml
+++ b/app/src/main/res/drawable/ic_audio_track.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,3v10.55c-0.59,-0.34 -1.27,-0.55 -2,-0.55c-2.21,0 -4,1.79 -4,4s1.79,4 4,4s4,-1.79 4,-4V7h4V3H12z" />
+</vector>

--- a/app/src/main/res/drawable/ic_playback_speed.xml
+++ b/app/src/main/res/drawable/ic_playback_speed.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,8v8l6,-4L10,8zM6.76,5.36L5.34,3.94C3.9,5.12 2.9,6.83 2.59,8.78h2.02C4.88,7.45 5.7,6.27 6.76,5.36zM4.61,12.22H2.59c0.31,1.95 1.31,3.66 2.75,4.84l1.42,-1.43C5.7,14.73 4.88,13.55 4.61,12.22zM6.76,18.49C7.94,19.46 9.4,20 11,20v-2c-1.06,0 -2.03,-0.36 -2.82,-0.95L6.76,18.49zM13,4.07V2.05C17.94,2.55 21.5,7 21,11.94c-0.42,4.25 -3.7,7.53 -7.95,7.95v-2.02c3.16,-0.4 5.6,-3.1 5.6,-6.37S16.16,4.47 13,4.07z" />
+</vector>

--- a/app/src/main/res/layout/content_controller_tv_series.xml
+++ b/app/src/main/res/layout/content_controller_tv_series.xml
@@ -357,6 +357,51 @@
             </FrameLayout>
 
             <FrameLayout
+                android:id="@+id/exo_audio"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_gravity="center"
+                android:layout_marginEnd="8dp"
+                android:background="@drawable/shape_play_pause_circle_bottom"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
+                android:nextFocusUp="@id/exo_progress"
+                android:visibility="gone">
+
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:duplicateParentState="true"
+                    android:padding="11dp"
+                    app:srcCompat="@drawable/ic_audio_track"
+                    app:tint="@color/color_black_white_text"
+                    app:tintMode="multiply" />
+
+            </FrameLayout>
+
+            <FrameLayout
+                android:id="@+id/exo_speed"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_gravity="center"
+                android:layout_marginEnd="8dp"
+                android:background="@drawable/shape_play_pause_circle_bottom"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
+                android:nextFocusUp="@id/exo_progress">
+
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:duplicateParentState="true"
+                    android:padding="11dp"
+                    app:srcCompat="@drawable/ic_playback_speed"
+                    app:tint="@color/color_black_white_text"
+                    app:tintMode="multiply" />
+
+            </FrameLayout>
+
+            <FrameLayout
                 android:id="@+id/exo_subtidtle"
                 android:layout_width="48dp"
                 android:layout_height="48dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,6 +194,14 @@
     <string name="anilist_library_empty">Your AniList list is empty.</string>
     <string name="anilist_status_empty">Nothing in “%1$s”.</string>
     <string name="anilist_exact_tracking">AniList ID</string>
+    <string name="player_audio_title">Ovoz</string>
+    <string name="player_audio_subtitle">Oqim ichidagi ovoz yo\'llari — dublyaj yoki original.</string>
+    <string name="player_speed_title">Tezlik</string>
+    <string name="player_speed_subtitle">Ijro tezligi. Epizod almashsa ham saqlanadi.</string>
+    <string name="player_speed_normal">Oddiy</string>
+    <string name="player_subtitle_title">Subtitr</string>
+    <string name="player_subtitle_subtitle">Oqim ichidagi subtitr yo\'llari.</string>
+    <string name="player_subtitle_off_hint">Subtitrsiz</string>
     <string name="player_quality_title">Video quality</string>
     <string name="player_quality_subtitle">Pick a resolution, or let the player follow your connection.</string>
     <string name="quality_auto">Auto</string>


### PR DESCRIPTION
ExoPlayer has always parsed every rendition in the manifest. The UI simply never asked.

## Audio

A new button, hidden until the stream actually offers a choice. A dual-audio release used to play whichever track the `setPreferredAudioLanguages("hin", "jpn", "eng")` list happened to match, with no way to say otherwise.

No **auto** entry, unlike quality — there is nothing to adapt to here. The player is following a guess, and this is the user overruling it.

Naming, in order: the manifest's own label where there is one (*"Hindi 5.1 Commentary"* beats anything derivable), otherwise the language code turned into a real language name, because `hin` is not something to put in front of a viewer. Channel layout (Mono/Stereo/5.1/7.1), codec and bitrate ride alongside as detail. A track this device cannot decode is left out rather than offered as silence.

## Subtitles inside the stream

The button keyed off the extractor's separate files alone, so **a stream carrying its own subtitle tracks showed no subtitle button at all** — parsed, selectable, and unreachable.

They get their own picker, because the two are genuinely different operations: an embedded track is an override the player applies instantly; an extractor subtitle rebuilds the media source around a downloaded file. The existing extractor path is untouched.

## Speed

It already existed — as a plain `AlertDialog` reachable from settings. Out of place on leanback, and it never got the D-pad focus treatment every other dialog in this player has. It now uses the same dialog as the rest, on its own button, and survives an episode change because it belongs to the viewer rather than to the stream.

## Correctness

- Overrides are cleared **by type**, so choosing an audio track cannot silently undo a pinned resolution.
- A text override also enables the renderer — without `setTrackTypeDisabled(TRACK_TYPE_TEXT, false)` the track is chosen and stays silent.
- Off means off: clearing the override alone would let the player pick a track again on the next selection pass.
- A pick cannot outlive the stream that declared it, so selections reset when the media changes.
- `onTracksChanged` fires during `release()`, which runs before `_binding` is cleared — guarded, following the pattern already used elsewhere in the fragment.

`assembleDebug` passes.