### PR TITLE
Fix the crashes an audit found, not the ones it guessed at

### DIFF
--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/detail/CastDetailAdapter.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/detail/CastDetailAdapter.kt
@@ -124,7 +124,7 @@ class CastDetailAdapter(
             Log.d("GGG", "bind:fuck WHy not shoewn ${model.media} ")
             val adapter = CategoriesPageAdapter(isDetail = true)
             adapter.setClickDetail {
-                LocalData.focusChangedListenerPlayerg.invoke(it)
+                LocalData.focusChangedListenerPlayerg?.invoke(it)
             }
             adapter.setCategoriesPageInterface(object :
                 CategoriesPageAdapter.CategoriesPageInterface {

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/detail/CastDetailScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/detail/CastDetailScreen.kt
@@ -62,14 +62,7 @@ class CastDetailScreen : Fragment(), CastDetailAdapter.DetailsInterface {
             // Real detail arrived (non-extension source) — hide the placeholder, show the grid.
             binding.castPlaceholder.gone()
             binding.vgvMovieDetails.visible()
-            LocalData.setFocusChangedListenerPlayer {
-                val intent =
-                    Intent(binding.root.context, PlayerActivity::class.java)
-                intent.putExtra("model", it.id)
-                intent.putExtra("isMovie", !it.isSeries)
-                requireActivity().startActivity(intent)
-                requireActivity().finishDeferred()
-            }
+            claimFocusToPlay()
             val headerData = CastAdapterModel(
                 image = it.image,
                 name = it.name,
@@ -130,6 +123,31 @@ class CastDetailScreen : Fragment(), CastDetailAdapter.DetailsInterface {
         } else {
             findNavController().popBackStack()
         }
+    }
+
+
+    /**
+     * Claims the shared focus-to-play callback for this screen.
+     *
+     * It lives in LocalData, one slot for the whole process, and Detail and
+     * CastDetail both write to it — so whichever ran last used to own it. Going
+     * Detail -> cast -> Back left the callback pointing at a fragment whose view
+     * was already gone. Re-claimed on every resume, so the screen the user is
+     * actually looking at is the one that hears about it.
+     */
+    private fun claimFocusToPlay() {
+        LocalData.setFocusChangedListenerPlayer {
+            val intent = Intent(requireContext(), PlayerActivity::class.java)
+            intent.putExtra("model", it.id)
+            intent.putExtra("isMovie", !it.isSeries)
+            requireActivity().startActivity(intent)
+            requireActivity().finishDeferred()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        claimFocusToPlay()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/detail/DetailPage.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/detail/DetailPage.kt
@@ -136,13 +136,7 @@ class DetailPage : Fragment(), MovieDetailsAdapter.DetailsInterface {
             val fourItem = details.copy(viewType = MovieDetailsAdapter.DETAILS_ITEM_FOUR)
             currentList.addAll(listOf(headerItem, sectionItem, thirdItem, fourItem))
             detailsAdapter.submitList(currentList)
-            LocalData.setFocusChangedListenerPlayer {
-                val intent = Intent(binding.root.context, PlayerActivity::class.java)
-                intent.putExtra("model", it.id)
-                intent.putExtra("isMovie", !it.isSeries)
-                requireActivity().startActivity(intent)
-                requireActivity().finishDeferred()
-            }
+            claimFocusToPlay()
         }
 
 
@@ -327,6 +321,31 @@ class DetailPage : Fragment(), MovieDetailsAdapter.DetailsInterface {
                 item.id
             ),
         )
+    }
+
+
+    /**
+     * Claims the shared focus-to-play callback for this screen.
+     *
+     * It lives in LocalData, one slot for the whole process, and Detail and
+     * CastDetail both write to it — so whichever ran last used to own it. Going
+     * Detail -> cast -> Back left the callback pointing at a fragment whose view
+     * was already gone. Re-claimed on every resume, so the screen the user is
+     * actually looking at is the one that hears about it.
+     */
+    private fun claimFocusToPlay() {
+        LocalData.setFocusChangedListenerPlayer {
+            val intent = Intent(requireContext(), PlayerActivity::class.java)
+            intent.putExtra("model", it.id)
+            intent.putExtra("isMovie", !it.isSeries)
+            requireActivity().startActivity(intent)
+            requireActivity().finishDeferred()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        claimFocusToPlay()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/detail/MovieDetailsAdapter.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/detail/MovieDetailsAdapter.kt
@@ -151,7 +151,7 @@ class MovieDetailsAdapter(
         private val recommendedAdapter = CategoriesPageAdapter(isDetail = true)
         fun bind() {
             recommendedAdapter.setClickDetail {
-                LocalData.focusChangedListenerPlayerg.invoke(it)
+                LocalData.focusChangedListenerPlayerg?.invoke(it)
             }
             recommendedAdapter.updateCategoriesAll(recommendedMovies as ArrayList<MainModel>)
             recommendedAdapter.setCategoriesPageInterface(object :

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/home/HomeAdapter.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/home/HomeAdapter.kt
@@ -246,7 +246,7 @@ class HomeAdapter(private val itemList: MutableList<HomeData> = mutableListOf())
         @SuppressLint("SetTextI18n")
         fun bind(item: BannerItem) {
             binding.root.setOnClickListener {
-                LocalData.listenerItemBanner.invoke(
+                LocalData.listenerItemBanner?.invoke(
                     item
                 )
 
@@ -371,7 +371,7 @@ class HomeAdapter(private val itemList: MutableList<HomeData> = mutableListOf())
             binding.topContainer.text = item.content.title
             binding.root.applyTvFocusScale()
             binding.root.setOnClickListener {
-                LocalData.sFocusedGenreClickListener.invoke(item.content.title)
+                LocalData.sFocusedGenreClickListener?.invoke(item.content.title)
             }
         }
     }
@@ -427,7 +427,7 @@ class HomeAdapter(private val itemList: MutableList<HomeData> = mutableListOf())
                 }
                 binding.root.applyTvFocusScale()
                 binding.root.setOnClickListener {
-                    LocalData.historyItemClickListenerr.invoke(getLocalEp)
+                    LocalData.historyItemClickListenerr?.invoke(getLocalEp)
                 }
                 itemImg.loadImage(getLocalEp.image)
 
@@ -442,7 +442,7 @@ class HomeAdapter(private val itemList: MutableList<HomeData> = mutableListOf())
             binding.channelName.text = item.content.title
             binding.channelGroup.text = item.content.country
             binding.root.setOnClickListener {
-                LocalData.channnelItemClickListener.invoke(item.content)
+                LocalData.channnelItemClickListener?.invoke(item.content)
             }
             binding.root.applyTvFocusScale()
 
@@ -460,7 +460,7 @@ class HomeAdapter(private val itemList: MutableList<HomeData> = mutableListOf())
             binding.root.apply {
                 applyTvFocusScale()
                 setOnClickListener {
-                    LocalData.listenerItemCategory.invoke(item)
+                    LocalData.listenerItemCategory?.invoke(item)
                 }
             }
             // Was "SOURCE · <internal id> · FORMAT" - the id is a database key the
@@ -507,7 +507,7 @@ class HomeAdapter(private val itemList: MutableList<HomeData> = mutableListOf())
             binding.root.apply {
                 applyTvFocusScale()
                 setOnClickListener {
-                    LocalData.viewAllClickListenerrr.invoke(item)
+                    LocalData.viewAllClickListenerrr?.invoke(item)
                 }
             }
         }

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/search/SearchScreen.kt
@@ -153,12 +153,28 @@ class SearchScreen : Fragment() {
         }
     }
 
+    /**
+     * Runs [block] on the UI thread only while there is still a view to touch.
+     *
+     * The speech recognizer is not lifecycle-aware: its callbacks keep arriving
+     * after the user has pressed Back, and both `requireActivity()` and the
+     * `binding` getter throw once the fragment is detached. One site was already
+     * guarded by hand, which is how this was found — the other five were not.
+     */
+    private inline fun onUi(crossinline block: () -> Unit) {
+        if (!isAdded || _binding == null) return
+        activity?.runOnUiThread {
+            if (!isAdded || _binding == null) return@runOnUiThread
+            block()
+        }
+    }
+
     private fun createRecognitionListener(isTV: Boolean): RecognitionListener {
         return object : RecognitionListener {
             override fun onReadyForSpeech(params: Bundle?) {
                 Log.d("SearchScreen", "Ready for speech")
                 isListening = true
-                requireActivity().runOnUiThread {
+                onUi {
                     showVoiceOverlay(true)
                     binding.voiceListeningOverlay.listeningTxt.text = "Listening..."
                     binding.micBtn.setImageResource(R.drawable.ic_mic)
@@ -167,7 +183,7 @@ class SearchScreen : Fragment() {
 
             override fun onBeginningOfSpeech() {
                 Log.d("SearchScreen", "Beginning of speech")
-                requireActivity().runOnUiThread {
+                onUi {
                     binding.voiceListeningOverlay.listeningTxt.text = "Listening... Speak now"
                 }
             }
@@ -180,7 +196,7 @@ class SearchScreen : Fragment() {
             override fun onEndOfSpeech() {
                 Log.d("SearchScreen", "End of speech")
                 isListening = false
-                requireActivity().runOnUiThread {
+                onUi {
                     binding.micBtn.setImageResource(R.drawable.ic_mic)
                 }
             }
@@ -202,7 +218,7 @@ class SearchScreen : Fragment() {
 
                 Log.e("SearchScreen", "Speech recognition error: $errorMessage")
 
-                requireActivity().runOnUiThread {
+                onUi {
                     showVoiceOverlay(false)
                     binding.micBtn.setImageResource(R.drawable.ic_mic)
 
@@ -238,7 +254,7 @@ class SearchScreen : Fragment() {
 
                 Log.d("SearchScreen", "Speech results: $spokenText")
 
-                requireActivity().runOnUiThread {
+                onUi {
                     showVoiceOverlay(false)
                     binding.micBtn.setImageResource(R.drawable.ic_mic)
 
@@ -269,8 +285,7 @@ class SearchScreen : Fragment() {
                     ?.firstOrNull()
                     ?.takeIf { it.isNotBlank() }
                     ?: return
-                requireActivity().runOnUiThread {
-                    if (_binding == null) return@runOnUiThread
+                onUi {
                     binding.voiceListeningOverlay.listeningTxt.text = partial
                 }
             }

--- a/app/src/main/java/com/saikou/sozo_tv/utils/LocalData.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/utils/LocalData.kt
@@ -16,12 +16,24 @@ import com.saikou.sozo_tv.domain.model.MainModel
 import com.saikou.sozo_tv.domain.model.MySpinnerItem
 
 object LocalData {
-    lateinit var historyItemClickListenerr: (WatchHistoryEntity) -> Unit
+
+    /*
+     * These callbacks are process-global and nothing clears them, so a screen
+     * that sets one keeps a reference to itself long after its view is gone —
+     * and two screens setting the same one means the last to run owns it.
+     *
+     * Nullable rather than lateinit: "no screen has claimed this yet" is an
+     * ordinary state, and lateinit turned it into an
+     * UninitializedPropertyAccessException at the first click. The screens that
+     * share one re-claim it in onResume, so whichever is actually on screen is
+     * the one that hears about it.
+     */
+    var historyItemClickListenerr: ((WatchHistoryEntity) -> Unit)? = null
     fun setHistoryItemClickListener(listener: (WatchHistoryEntity) -> Unit) {
         historyItemClickListenerr = listener
     }
 
-    lateinit var viewAllClickListenerrr: (ViewAllData) -> Unit
+    var viewAllClickListenerrr: ((ViewAllData) -> Unit)? = null
     fun setViewAllClickListenerf(listener: (ViewAllData) -> Unit) {
         viewAllClickListenerrr = listener
     }
@@ -259,7 +271,7 @@ object LocalData {
 
     val years = (1970..java.util.Calendar.getInstance().get(java.util.Calendar.YEAR))
         .map { MySpinnerItem(it.toString()) }.reversed().toMutableList()
-    lateinit var sFocusedGenreClickListener: (String) -> Unit
+    var sFocusedGenreClickListener: ((String) -> Unit)? = null
 
     fun setFocusedGenreClickListener(listener: (String) -> Unit) {
         sFocusedGenreClickListener = listener
@@ -274,12 +286,12 @@ object LocalData {
         SectionItem(MyApp.context.getString(R.string.message_page), R.drawable.ic_chat),
         SectionItem(MyApp.context.getString(R.string.anilist), R.drawable.ic_anilist_badge),
     )
-    lateinit var listenerItemCategory: (isAbout: CategoryDetails) -> Unit
+    var listenerItemCategory: ((isAbout: CategoryDetails) -> Unit)? = null
     fun setonClickedListenerItemCategory(listener: (isAbout: CategoryDetails) -> Unit) {
         listenerItemCategory = listener
     }
 
-    lateinit var listenerItemBanner: (isAbout: BannerItem) -> Unit
+    var listenerItemBanner: ((isAbout: BannerItem) -> Unit)? = null
     fun setonClickedlistenerItemBanner(listener: (isAbout: BannerItem) -> Unit) {
         listenerItemBanner = listener
     }
@@ -287,13 +299,13 @@ object LocalData {
     val recommendedMovies: MutableList<MainModel> = mutableListOf()
     val recommendedMoviesCast: MutableList<MainModel> = mutableListOf()
     val castList: MutableList<Cast> = mutableListOf()
-    lateinit var focusChangedListenerPlayerg: (MainModel) -> Unit
+    var focusChangedListenerPlayerg: ((MainModel) -> Unit)? = null
 
     fun setFocusChangedListenerPlayer(listener: (MainModel) -> Unit) {
         focusChangedListenerPlayerg = listener
     }
 
-    lateinit var channnelItemClickListener: (ChannelResponseItem) -> Unit
+    var channnelItemClickListener: ((ChannelResponseItem) -> Unit)? = null
     fun setChannelItemClickListener(listener: (ChannelResponseItem) -> Unit) {
         channnelItemClickListener = listener
     }

--- a/app/src/main/res/layout/history_alert_dialog.xml
+++ b/app/src/main/res/layout/history_alert_dialog.xml
@@ -56,7 +56,7 @@
                 android:layout_height="80dp"
                 android:scaleType="centerCrop"
                 android:src="@drawable/delete_all"
-                android:tint="@color/red" />
+                app:tint="@color/red" />
 
 
         </LinearLayout>

--- a/app/src/main/res/layout/item_view_all.xml
+++ b/app/src/main/res/layout/item_view_all.xml
@@ -31,7 +31,7 @@
                 android:layout_height="22dp"
                 android:layout_gravity="center"
                 android:src="@drawable/ic_next"
-                android:tint="@color/netflix_white" />
+                app:tint="@color/netflix_white" />
         </FrameLayout>
 
         <TextView

--- a/app/src/main/res/layout/skip_intro_layout.xml
+++ b/app/src/main/res/layout/skip_intro_layout.xml
@@ -58,7 +58,7 @@
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 
-    Auto-skip button - shown when auto-skip is ENABLED
+    <!-- Auto-skip button - shown when auto-skip is ENABLED -->
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/skip_intro_button"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/view_tv_dropdown_section.xml
+++ b/app/src/main/res/layout/view_tv_dropdown_section.xml
@@ -77,7 +77,7 @@
             android:layout_width="28dp"
             android:layout_height="28dp"
             android:src="@drawable/ic_chevron_down"
-            android:tint="@color/netflix_gray" />
+            app:tint="@color/netflix_gray" />
 
     </LinearLayout>
 


### PR DESCRIPTION
A systematic sweep of the TV app — dead UI, view-outliving callbacks, unconditional-failure methods, and Android lint — rather than a read-through.

## Voice search crashed on Back

`RecognitionListener` is not lifecycle-aware: callbacks keep arriving after the fragment is detached, and **both** `requireActivity()` and the `binding` getter throw at that point.

Five of the six sites were unguarded. The sixth had a hand-written `if (_binding == null) return@runOnUiThread` — that inconsistency is what surfaced it: somebody hit this crash once and patched only where it landed. All six now go through one helper that checks on both sides of the thread hop.

## Seven global listeners, zero guards

`LocalData` holds seven `lateinit var` callbacks. Across **eight** invocation sites there was not one `isInitialized` check, so an adapter firing before any screen had claimed the slot threw `UninitializedPropertyAccessException`. "No screen has claimed this yet" is an ordinary state, not a crash — they are nullable now.

## Two screens fighting over one slot

`Detail` and `CastDetail` both write `focusChangedListenerPlayer`, and both register inside a data-arrival observer that does not run again on the way back.

**Detail → cast → Back** left the global pointing at a fragment whose view was already gone. Both re-claim it in `onResume`, so the screen actually on display owns it.

## Smaller, real

- A comment in `skip_intro_layout.xml` had lost its `<!-- -->` and sat in the tree as a text node.
- Three icons used `android:tint` where AppCompat only honours `app:tint`, so they kept their source colour.

## Checked and deliberately left alone

| lint says | why it is wrong |
|---|---|
| `RepeatOnLifecycleWrongUsage` in the player | `observeRemote()` runs only from `initializeVideo`, which early-returns once the player exists — no repeat collection |
| `NullSafeMutableLiveData` in `SplashViewModel` | the write is already inside `if (update != null)`; lint cannot see through the smart cast |

Two other suspicions I chased and dropped: `DetailPage`'s 15-second timeout already checks `_binding != null` **and** removes its callback, and the player's progress `Handler` is nulled with its callbacks removed. Both safe.

Also dead but harmless, reported rather than touched: `characterDetail`/`creditDetail` can still only fail (the cast row is already non-clickable), `loadRandomAnime` has no live caller, and three layouts — `recent_search_item`, `item_content_mode_section`, `view_netflix_filter_selector` — are never inflated at all.

`assembleDebug` passes.