### PR TITLE
Recover from a codec the box does not have, and stop stretching one row

### DIFF
--- a/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/screens/play/SeriesPlayerScreen.kt
@@ -33,6 +33,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.media3.common.Tracks
 import com.saikou.sozo_tv.data.model.SubTitle
+import com.saikou.sozo_tv.utils.snackString
 import com.saikou.sozo_tv.domain.player.NativeQualities
 import com.saikou.sozo_tv.domain.player.NativeTracks
 import com.saikou.sozo_tv.domain.player.VideoOptionGroups
@@ -548,6 +549,7 @@ class SeriesPlayerScreen : Fragment() {
                 Log.e("PLAYER_ERR", "code=${error.errorCodeName}", error)
                 showBuffering(false)
                 Bugsnag.notify(Exception("GGGG:${model.seriesResponse?.urlobj} || ${model.parser.name}" + error.message))
+                handlePlaybackError(error)
             }
 
             @SuppressLint("SwitchIntDef")
@@ -852,6 +854,7 @@ class SeriesPlayerScreen : Fragment() {
         // survive a reload. Back to auto rather than to a stale override.
         selectedNativeQuality = null
         selectedAudio = null
+        autoFallbackTries = 0
         selectedText = null
         applyNativeQuality()
         // Speed is the user's, not the stream's, so it is deliberately kept.
@@ -907,6 +910,52 @@ class SeriesPlayerScreen : Fragment() {
      * is now overruling. Listing the tracks and marking the current one is the
      * whole of it.
      */
+
+    /**
+     * What to do when playback dies.
+     *
+     * It used to log, notify Bugsnag, and stop — leaving a black screen with no
+     * explanation and no way forward. The most common cause on TV boxes is a
+     * codec the device does not have: an HEVC release plays on one stick and
+     * not on the next, and ExoPlayer says so precisely
+     * (format_supported=NO_EXCEEDS_CAPABILITIES) before failing.
+     *
+     * Another source usually carries the same episode in a format this box CAN
+     * decode, so the first response is to move to one rather than to ask the
+     * user to. Only when there is nothing left to try does it explain itself.
+     */
+    @OptIn(UnstableApi::class)
+    private fun handlePlaybackError(error: PlaybackException) {
+        val options = model.videoOptionsData.value.orEmpty()
+        val decodeProblem = error.errorCode == PlaybackException.ERROR_CODE_DECODING_FAILED ||
+            error.errorCode == PlaybackException.ERROR_CODE_DECODER_INIT_FAILED ||
+            error.errorCode == PlaybackException.ERROR_CODE_DECODING_FORMAT_UNSUPPORTED
+
+        val next = model.currentSelectedVideoOptionIndex + 1
+        if (decodeProblem && next in options.indices && autoFallbackTries < MAX_AUTO_FALLBACK) {
+            autoFallbackTries++
+            model.currentSelectedVideoOptionIndex = next
+            ignoreNextEpisodeSuccess = true
+            snackString(getString(R.string.player_switching_source), requireActivity())
+            model.updateQualityByIndex()
+            return
+        }
+
+        val message = when {
+            decodeProblem -> getString(R.string.player_error_codec)
+            error.errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED ||
+                error.errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT ->
+                getString(R.string.player_error_network)
+            else -> getString(R.string.player_error_generic)
+        }
+        snackString(message, requireActivity())
+    }
+
+    /** Reset per episode: a new stream deserves its own budget of attempts. */
+    private var autoFallbackTries = 0
+
+    private val MAX_AUTO_FALLBACK = 2
+
     @OptIn(UnstableApi::class)
     private fun showAudioDialog() {
         val options = NativeTracks.audio(player.currentTracks)

--- a/app/src/main/res/layout/dialog_video_quality.xml
+++ b/app/src/main/res/layout/dialog_video_quality.xml
@@ -58,7 +58,8 @@
         <androidx.leanback.widget.VerticalGridView
             android:id="@+id/videOptionRv"
             android:layout_width="match_parent"
-            android:layout_height="200dp"
+            android:layout_height="wrap_content"
+            android:maxHeight="260dp"
             android:clipToPadding="false"
             android:focusable="true"
             android:scrollbars="none"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,6 +194,10 @@
     <string name="anilist_library_empty">Your AniList list is empty.</string>
     <string name="anilist_status_empty">Nothing in “%1$s”.</string>
     <string name="anilist_exact_tracking">AniList ID</string>
+    <string name="player_switching_source">Bu format qurilmada ochilmadi — boshqa manbaga o\'tilmoqda…</string>
+    <string name="player_error_codec">Bu qurilma shu video formatini (HEVC) ocholmaydi. Boshqa sifat yoki serverni tanlang.</string>
+    <string name="player_error_network">Tarmoq uzildi. Ulanishni tekshirib qayta urining.</string>
+    <string name="player_error_generic">Video ochilmadi. Boshqa server yoki sifatni tanlab ko\'ring.</string>
     <string name="player_audio_title">Ovoz</string>
     <string name="player_audio_subtitle">Oqim ichidagi ovoz yo\'llari — dublyaj yoki original.</string>
     <string name="player_speed_title">Tezlik</string>


### PR DESCRIPTION
## The crash in the log

```
MediaCodecVideoRenderer error, format=Format(..., video/hevc, hvc1.2.4.L93.90, ...),
format_supported=NO_EXCEEDS_CAPABILITIES
Caused by: MediaCodecVideoDecoderException: Decoder failed: c2.goldfish.hevc.decoder
PLAYER_ERR  code=ERROR_CODE_DECODING_FAILED
```

ExoPlayer knew the device could not decode that track **before** it tried. `onPlayerError` logged it, notified Bugsnag, and stopped — leaving a black screen with nothing said and no way forward.

Another source almost always carries the same episode in something the box *can* decode, so the first response is now to move to one rather than ask the user to, with a line saying so. Bounded at two attempts: walking an entire server list one dead codec at a time is its own kind of hang.

When there is nothing left to try, the reason is finally said out loud — codec, network, or neither — instead of a black screen.

## The stretched row

`videOptionRv` was a fixed `200dp`. With a single entry, that entry stretched to fill all of it: one server rendered as a box taller than the dialog's own title. It sizes to its contents now, capped at 260dp so a long list still scrolls rather than growing off-screen.

`assembleDebug` passes.