### PR TITLE
Restart at 1.0.0 on a new signing key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,12 @@ run-name: >-
 #                             cannot message a person by @username; each
 #                             recipient must press Start on the bot once.
 #
-# The keystore MUST be the one already on devices (CN=Sozo Tv, O=Sozo LLC). A
-# different certificate cannot be installed over an existing copy: users get
-# "package conflicts with an existing package" and have to uninstall, losing
-# their history. The build verifies the fingerprint and refuses to ship anything
-# else — see EXPECTED_CERT_SHA256 below.
+# The signing key was replaced on 22 Aug 2026 because the original was lost, and
+# the version line restarted at 1.0.0 with it. A different certificate cannot be
+# installed over an existing copy: anyone still running a pre-1.0.0 build gets
+# "package conflicts with an existing package" and has to uninstall first. The
+# build still verifies the fingerprint and refuses to ship anything signed by
+# another key — see EXPECTED_CERT_SHA256 below.
 
 on:
   workflow_dispatch:
@@ -272,7 +273,7 @@ jobs:
 
       - name: Verify the APK is signed by the expected certificate
         env:
-          EXPECTED_CERT_SHA256: cc23741adc1f7df57f62107bdd65d8bd15197ef34605dec5bfa7fae57ed620f8
+          EXPECTED_CERT_SHA256: c952cee4c758db729767b5499cfd63cca17a51a319142e4d30fcb4e3237ca07f
         run: |
           set -euo pipefail
           APKSIGNER="$(find "${ANDROID_HOME:-$ANDROID_SDK_ROOT}/build-tools" -name apksigner | sort | tail -1)"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,8 +54,8 @@ android {
         minSdk = 24
         //noinspection OldTargetApi
         targetSdk = 35
-        versionCode = 10
-        versionName = "10.0"
+        versionCode = 1
+        versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/SplashViewModel.kt
+++ b/app/src/main/java/com/saikou/sozo_tv/presentation/viewmodel/SplashViewModel.kt
@@ -52,7 +52,7 @@ class SplashViewModel(
                 ?.takeIf { it.isActionable && (it.version ?: 0L) > current }
                 ?.toAppUpdate()
 
-            if (update != null) getAppUpdateInfo.value = update
+            update?.let { getAppUpdateInfo.value = it }
             isUpdateAvailableLiveData.value = update != null
         }
     }


### PR DESCRIPTION
The original release keystore is gone, so nothing can be signed with it again. This replaces it and restarts the version line.

## New signing key

Generated with the same identity as before — `CN=Sozo Tv, O=Sozo LLC`, RSA 4096, valid to 2054 — and both secrets are already set on this repo:

| secret | |
|---|---|
| `ANDROID_TV_KEYSTORE_B64` | set |
| `ANDROID_TV_KEY_PROPERTIES` | set |
| `RELEASE_PAT` | was already set |

`EXPECTED_CERT_SHA256` now names the key we actually hold:

```
cc23741adc1f7df57f62107bdd65d8bd15197ef34605dec5bfa7fae57ed620f8   (lost)
c952cee4c758db729767b5499cfd63cca17a51a319142e4d30fcb4e3237ca07f   (new)
```

That step exists to stop the wrong key shipping, so it has to be updated deliberately rather than loosened.

## Version restarts at 1.0.0

`versionCode 10 → 1`, `versionName "10.0" → "1.0.0"`.

Carrying 10 forward onto a certificate no device recognises would be the worst of both: users still have to uninstall before they can install, and the number implies an upgrade path that no longer exists.

The seven old tags (`v1.0` … `v10.0`) are deleted from the remote so `v1.0.0` is free. **The seven GitHub Releases are untouched** — the old APKs remain downloadable, they just no longer point at a tag.

## One unrelated blocker fixed

`lintVitalRelease` failed the release build — not from anything in this change:

```
SplashViewModel.kt:55: Error: Expected non-nullable value [NullSafeMutableLiveData]
    if (update != null) getAppUpdateInfo.value = update
```

Lint does not follow the smart cast. Assigning through `?.let` states the same thing in a form it can see. No baseline was added — the check is worth keeping.

## Verified locally

```
./gradlew :app:assembleRelease            → exit 0
apksigner verify --print-certs            → c952cee4…237ca07f   (matches EXPECTED_CERT_SHA256)
aapt2 dump badging                        → versionCode='1' versionName='1.0.0'
```

## After merging

Release by pushing the tag, so the workflow takes the committed version verbatim instead of bumping it:

```
git tag v1.0.0 && git push origin v1.0.0
```

`TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_IDS` are still unset. That does not fail the build — the step warns and the APK is attached to the run as an artifact.

**Keep a backup of the new keystore off this machine.** If it is lost the same way, the version line has to restart again and every user has to uninstall again.
